### PR TITLE
feat: v1.0 — transport hardening, 43 new methods, bug fixes

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,48 @@
+# TODOS
+
+Deferred work captured during gstack eng review, 2026-03-22.
+
+---
+
+## TODO 1 — Evaluate watcher/restriction methods for v1.0 Confluence scope
+
+**What:** Decide whether `watch_page`, `get_page_watchers`, and `update_content_restrictions` belong in v1.0 or move to v1.1.
+
+**Why:** These 3 methods were accepted in the CEO SELECTIVE EXPANSION review but immediately flagged as Reviewer Concerns. They serve a niche audience (watcher management, content restrictions) that may not align with the core DevOps/CI user who automates page creation and updates.
+
+**Pros of including:** Completes the Confluence v1.0 surface; avoids API churn for users who do need them.
+**Cons:** 3 more methods to test, document, and maintain. If the target audience doesn't use them, they're dead weight that dilutes the "quality per endpoint" positioning.
+
+**Context:** No technical blocker — purely a product judgment call. The eng review confirmed no API availability issues (both are in Confluence Server/DC REST API). Decision should be made before Confluence implementation begins.
+
+**Depends on:** Nothing. Can be resolved independently.
+
+---
+
+## TODO 2 — Version matrix: document which Jira/Confluence Server/DC versions are supported
+
+**What:** Create a compatibility table in the README listing the minimum Jira Server/DC and Confluence Server/DC versions tested against each library version.
+
+**Why:** The Agile API, attachment endpoints, content restrictions, and watcher APIs vary by product version. Without a matrix, users hitting version-specific 404s have no way to know if it's a bug or an unsupported version. "Quality per endpoint" needs to define what quality means on which versions.
+
+**Pros:** Reduces support issues; builds trust with DevOps/CI users who care about version guarantees; differentiates on quality.
+**Cons:** Requires reading Atlassian release notes to determine minimum versions, and ideally some integration testing.
+
+**Context:** The Jira Software Agile REST API (`/rest/agile/1.0/`) requires a Jira Software license (not Jira Core). Confluence restrictions API availability varies by version. Currently the README mentions no version requirements at all. A starting point: Jira Agile API available since Jira Software 7.x; Confluence REST API since Confluence 5.5.
+
+**Depends on:** v1.0 method list finalized (TODO 1 resolved first).
+
+---
+
+## TODO 3 — Jira Cloud support (v1.1): design correct Basic auth and URL routing
+
+**What:** Implement `cloud=True` with correct auth — `Jira(url=..., cloud=True, email='user@example.com', token='api_token')` using Basic auth: `base64(email:token)`.
+
+**Why:** Cloud was deferred from v1.0 because the existing `token=` parameter creates a Bearer auth header, which Jira Cloud rejects (Cloud API tokens use Basic auth with email as username). Without fixing this, any `cloud=True` implementation would silently fail to authenticate.
+
+**Pros:** Unlocks the Jira Cloud user segment (2,800/month downloads, some must be cloud users); correct Cloud auth from day one differentiates from `atlassian-python-api` which has undocumented Cloud auth caveats.
+**Cons:** Requires URL rewriting (all hardcoded `/rest/api/2/` paths must route to `/rest/api/3/` when cloud=True), new auth path in `client.py`, significant test work.
+
+**Context:** Constructor change: add `cloud=False` + `cloud_email=None` params. When `cloud=True`, call `_create_basic_session(cloud_email, token)` instead of Bearer. URL routing: add `_api_version` property to `Jira` that returns `3` when `cloud=True`, `2` otherwise. Update all URL f-strings: `f"/rest/api/{self._api_version}/issue/{key}"`. All existing tests remain green since `cloud=False` is the default. v1.0 read-only constraint is still valid for v1.1 initial Cloud release.
+
+**Depends on:** v1.0 shipped and stable. Do not implement Cloud before v1.0 is finalized.

--- a/atlassian/client.py
+++ b/atlassian/client.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import os
 import requests  # type: ignore
 import json
+from typing import Any
 from types import SimpleNamespace, TracebackType
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 from .error import APIError
 from .logger import get_logger
 
@@ -28,6 +32,7 @@ class AtlassianAPI:
         timeout: int = 60,
         session: requests.Session | None = None,
         token: str | None = None,
+        max_retries: int = 0,
     ) -> None:
         """
         Initialize the AtlassianAPI instance.
@@ -44,6 +49,10 @@ class AtlassianAPI:
         :type session: requests.Session, optional
         :param token: The token for bearer authentication (optional).
         :type token: str, optional
+        :param max_retries: Number of retries for 429/503 responses (default 0, disabled).
+            Requires requests>=2.25.0. Uses exponential backoff with backoff_factor=0.5
+            and honours Retry-After headers.
+        :type max_retries: int, optional
         """
         self.url = url.strip("/")
         self.username = username
@@ -53,6 +62,16 @@ class AtlassianAPI:
             self._session = requests.Session()
         else:
             self._session = session
+        if max_retries > 0:
+            retry = Retry(
+                total=max_retries,
+                status_forcelist=[429, 503],
+                backoff_factor=0.5,
+                respect_retry_after_header=True,
+            )
+            adapter = HTTPAdapter(max_retries=retry)
+            self._session.mount("https://", adapter)
+            self._session.mount("http://", adapter)
         if username and password:
             try:
                 self._create_basic_session(username, password)
@@ -153,6 +172,8 @@ class AtlassianAPI:
         data: dict | None = None,
         json: object | None = None,
         params: dict | None = None,
+        files: dict | None = None,
+        headers: dict | None = None,
     ) -> requests.Response:
         """
         Make an HTTP request.
@@ -167,22 +188,33 @@ class AtlassianAPI:
         :type json: object or None
         :param params: The query parameters for the request (optional).
         :type params: dict or None
+        :param files: Multipart file payload for upload requests (optional).
+            When provided, Content-Type is set automatically by requests.
+        :type files: dict or None
+        :param headers: Per-request headers to merge with session headers (optional).
+        :type headers: dict or None
         :return: The HTTP response object.
         :rtype: requests.Response
-        :raises APIError: If the response status code is 4xx or 5xx.
+        :raises APIError: If the response status code is 4xx/5xx or a network
+            error occurs (code -1).
         """
-        if path:
-            url = self.url + path
-        else:
-            url = self.url
-        response = self._session.request(
-            method=method,
-            url=url,
-            data=data,
-            json=json,
-            params=params,
-            timeout=self.timeout,
-        )
+        url = self.url + path if path else self.url
+        kwargs: dict = {
+            "method": method,
+            "url": url,
+            "data": data,
+            "json": json,
+            "params": params,
+            "timeout": self.timeout,
+        }
+        if files is not None:
+            kwargs["files"] = files
+        if headers is not None:
+            kwargs["headers"] = headers
+        try:
+            response = self._session.request(**kwargs)
+        except requests.exceptions.RequestException as e:
+            raise APIError(-1, str(e)) from e
         response.encoding = "utf-8"
         logger.debug(f"HTTP: {method} -> {response.status_code} {response.reason}")
         if response.status_code >= 400:
@@ -223,7 +255,7 @@ class AtlassianAPI:
         self,
         path: str,
         data: dict | None = None,
-        json: dict | None = None,
+        json: Any = None,
         params: dict | None = None,
     ) -> dict | None:
         """
@@ -293,3 +325,35 @@ class AtlassianAPI:
         """
         response = self.request("DELETE", path, data=data, json=json, params=params)
         return self._response_handler(response)
+
+    def upload(
+        self,
+        path: str,
+        file_path: str,
+        mime_type: str = "application/octet-stream",
+    ) -> dict | None:
+        """
+        Upload a file via multipart POST.
+
+        Sends the file through the shared ``request()`` path so retry, timeout,
+        and error-wrapping behaviour is consistent with all other calls.
+        The ``X-Atlassian-Token: nocheck`` header is injected automatically to
+        satisfy Atlassian's XSRF protection on attachment endpoints.
+
+        :param path: The API endpoint path (e.g. ``/rest/api/2/issue/{key}/attachments``).
+        :type path: str
+        :param file_path: Absolute or relative path to the local file to upload.
+        :type file_path: str
+        :param mime_type: MIME type for the file (default ``application/octet-stream``).
+        :type mime_type: str, optional
+        :return: The parsed JSON response or None.
+        :rtype: dict or None
+        :raises APIError: If the response status code is 4xx/5xx or a network error occurs.
+        """
+        file_name = os.path.basename(file_path)
+        with open(file_path, "rb") as fh:
+            files = {"file": (file_name, fh, mime_type)}
+            response = self.request(
+                "POST", path, files=files, headers={"X-Atlassian-Token": "nocheck"}
+            )
+            return self._response_handler(response)

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -4,6 +4,7 @@ from typing import Any
 from types import SimpleNamespace
 
 from atlassian.client import AtlassianAPI
+from atlassian.error import APIError
 from atlassian.logger import get_logger
 
 logger = get_logger(__name__)
@@ -74,6 +75,11 @@ class Confluence(AtlassianAPI):
         """
         Update existing content in Confluence.
 
+        Fetches the current version number before writing so the PUT is always
+        sent with the correct version.  Concurrent writes may still produce a
+        409 Conflict — that is propagated as :class:`~atlassian.error.APIError`
+        and is the caller's responsibility to handle.
+
         :param page_id: The ID of the content to update.
         :type page_id: int
         :param title: The new title of the content.
@@ -84,10 +90,15 @@ class Confluence(AtlassianAPI):
         :type type: str
         :return: The response from the API.
         :rtype: dict or None
+        :raises APIError: If the current version cannot be fetched, or if the
+            server returns an error (including 409 Conflict on concurrent write).
         """
+        version = self.get_content_version(page_id)
+        if version is None:
+            raise APIError(-1, f"Unable to retrieve current version for page {page_id}")
         url = f"/rest/api/content/{page_id}"
         json = {
-            "version": {"number": 2},
+            "version": {"number": version + 1},
             "title": f"{title}",
             "type": f"{type}",
             "body": {
@@ -131,3 +142,325 @@ class Confluence(AtlassianAPI):
         """
         url = f"/rest/api/content/{page_id}/history"
         return self.get(url)
+
+    def get_content_version(self, page_id: int) -> int | None:
+        """
+        Retrieve the current version number of a page.
+
+        Uses the content history endpoint.  Returns ``None`` if the version
+        cannot be determined (e.g. the page does not exist or the response is
+        malformed).
+
+        :param page_id: The ID of the content.
+        :type page_id: int
+        :return: The current version number, or None.
+        :rtype: int or None
+        """
+        response = self.get_content_history(page_id)
+        if response is None or isinstance(response, str):
+            return None
+        try:
+            return response.lastUpdated.number
+        except AttributeError:
+            return None
+
+    # ------------------------------------------------------------------ #
+    # Search & spaces                                                      #
+    # ------------------------------------------------------------------ #
+
+    def search_content(
+        self,
+        cql: str,
+        limit: int = 25,
+    ) -> SimpleNamespace | str | None:
+        """
+        Search Confluence content using CQL.
+
+        :param cql: A CQL query string (e.g. ``'type=page AND space="MYSPACE"'``).
+        :type cql: str
+        :param limit: Maximum number of results (default 25).
+        :type limit: int, optional
+        :return: A SimpleNamespace containing the search results.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = "/rest/api/content/search"
+        return self.get(url, params={"cql": cql, "limit": limit})
+
+    def get_space(self, space_key: str) -> SimpleNamespace | str | None:
+        """
+        Get a space by key.
+
+        :param space_key: The space key.
+        :type space_key: str
+        :return: A SimpleNamespace containing the space details.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"/rest/api/space/{space_key}"
+        return self.get(url)
+
+    def list_spaces(self, limit: int = 25) -> SimpleNamespace | str | None:
+        """
+        List all spaces visible to the current user.
+
+        :param limit: Maximum number of spaces to return (default 25).
+        :type limit: int, optional
+        :return: A SimpleNamespace containing the list of spaces.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = "/rest/api/space"
+        return self.get(url, params={"limit": limit})
+
+    # ------------------------------------------------------------------ #
+    # Page hierarchy                                                       #
+    # ------------------------------------------------------------------ #
+
+    def get_page_children(self, page_id: int) -> SimpleNamespace | str | None:
+        """
+        Get child pages of a page.
+
+        :param page_id: The ID of the parent page.
+        :type page_id: int
+        :return: A SimpleNamespace containing the child pages.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"/rest/api/content/{page_id}/child/page"
+        return self.get(url)
+
+    def get_page_ancestors(self, page_id: int) -> SimpleNamespace | str | None:
+        """
+        Get ancestor pages of a page.
+
+        :param page_id: The ID of the page.
+        :type page_id: int
+        :return: A SimpleNamespace containing the ancestor pages.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"/rest/api/content/{page_id}/ancestor"
+        return self.get(url)
+
+    def move_page(
+        self,
+        page_id: int,
+        target_id: int,
+        position: str = "append",
+    ) -> dict | None:
+        """
+        Move a page relative to another page.
+
+        :param page_id: The ID of the page to move.
+        :type page_id: int
+        :param target_id: The ID of the target page.
+        :type target_id: int
+        :param position: Position relative to the target: ``"before"``,
+            ``"after"``, or ``"append"`` (default).
+        :type position: str, optional
+        :return: The response from the API.
+        :rtype: dict or None
+        :raises ValueError: If *position* is not a valid value.
+        """
+        valid_positions = ("before", "after", "append")
+        if position not in valid_positions:
+            raise ValueError(
+                f"position must be one of {valid_positions}, got {position!r}"
+            )
+        url = f"/rest/api/content/{page_id}/move/{position}/{target_id}"
+        return self.put(url)
+
+    # ------------------------------------------------------------------ #
+    # Attachments                                                          #
+    # ------------------------------------------------------------------ #
+
+    def add_attachment(
+        self,
+        page_id: int,
+        file_path: str,
+        mime_type: str = "application/octet-stream",
+    ) -> dict | None:
+        """
+        Attach a file to a page.
+
+        :param page_id: The ID of the page.
+        :type page_id: int
+        :param file_path: Path to the local file to attach.
+        :type file_path: str
+        :param mime_type: MIME type of the file (default ``application/octet-stream``).
+        :type mime_type: str, optional
+        :return: The attachment metadata returned by the API.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/content/{page_id}/child/attachment"
+        return self.upload(url, file_path, mime_type)
+
+    def get_attachments(self, page_id: int) -> SimpleNamespace | str | None:
+        """
+        Get attachments for a page.
+
+        :param page_id: The ID of the page.
+        :type page_id: int
+        :return: A SimpleNamespace containing the attachment metadata.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"/rest/api/content/{page_id}/child/attachment"
+        return self.get(url)
+
+    def delete_attachment(self, attachment_id: str) -> dict | None:
+        """
+        Delete an attachment by ID.
+
+        :param attachment_id: The ID of the attachment content object.
+        :type attachment_id: str
+        :return: The response from the API.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/content/{attachment_id}"
+        return self.delete(url)
+
+    # ------------------------------------------------------------------ #
+    # Labels                                                               #
+    # ------------------------------------------------------------------ #
+
+    def get_labels(self, page_id: int) -> SimpleNamespace | str | None:
+        """
+        Get labels for a page.
+
+        :param page_id: The ID of the page.
+        :type page_id: int
+        :return: A SimpleNamespace containing the labels.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"/rest/api/content/{page_id}/label"
+        return self.get(url)
+
+    def add_label(self, page_id: int, label: str) -> dict | None:
+        """
+        Add a label to a page.
+
+        :param page_id: The ID of the page.
+        :type page_id: int
+        :param label: The label name to add.
+        :type label: str
+        :return: The response from the API.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/content/{page_id}/label"
+        payload = [{"prefix": "global", "name": label}]
+        return self.post(url, json=payload)
+
+    def remove_label(self, page_id: int, label: str) -> dict | None:
+        """
+        Remove a label from a page.
+
+        :param page_id: The ID of the page.
+        :type page_id: int
+        :param label: The label name to remove.
+        :type label: str
+        :return: The response from the API.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/content/{page_id}/label"
+        return self.delete(url, params={"name": label})
+
+    # ------------------------------------------------------------------ #
+    # Comments                                                             #
+    # ------------------------------------------------------------------ #
+
+    def get_comments(self, page_id: int) -> SimpleNamespace | str | None:
+        """
+        Get comments on a page.
+
+        :param page_id: The ID of the page.
+        :type page_id: int
+        :return: A SimpleNamespace containing the comments.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"/rest/api/content/{page_id}/child/comment"
+        return self.get(url)
+
+    def add_comment(self, page_id: int, body: str) -> dict | None:
+        """
+        Add a comment to a page.
+
+        :param page_id: The ID of the page to comment on.
+        :type page_id: int
+        :param body: The comment body in Confluence storage format.
+        :type body: str
+        :return: The created comment object.
+        :rtype: dict or None
+        """
+        url = "/rest/api/content"
+        payload: dict[str, Any] = {
+            "type": "comment",
+            "container": {"id": page_id, "type": "page"},
+            "body": {"storage": {"value": body, "representation": "storage"}},
+        }
+        return self.post(url, json=payload)
+
+    def delete_comment(self, comment_id: int) -> dict | None:
+        """
+        Delete a comment.
+
+        :param comment_id: The ID of the comment content object.
+        :type comment_id: int
+        :return: The response from the API.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/content/{comment_id}"
+        return self.delete(url)
+
+    # ------------------------------------------------------------------ #
+    # Restrictions & discovery                                             #
+    # ------------------------------------------------------------------ #
+
+    def get_content_restrictions(self, page_id: int) -> SimpleNamespace | str | None:
+        """
+        Get restrictions on a page.
+
+        :param page_id: The ID of the page.
+        :type page_id: int
+        :return: A SimpleNamespace containing the restrictions.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"/rest/api/content/{page_id}/restriction"
+        return self.get(url)
+
+    def get_content_by_title(
+        self, space_key: str, title: str
+    ) -> SimpleNamespace | str | None:
+        """
+        Find a page by title within a space.
+
+        :param space_key: The space key.
+        :type space_key: str
+        :param title: The exact page title.
+        :type title: str
+        :return: A SimpleNamespace containing the matching content.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = "/rest/api/content"
+        return self.get(
+            url, params={"spaceKey": space_key, "title": title, "type": "page"}
+        )
+
+    def search_content_by_label(
+        self,
+        label: str,
+        space_key: str | None = None,
+        limit: int = 25,
+    ) -> SimpleNamespace | str | None:
+        """
+        Search pages by label.
+
+        :param label: The label to search for.
+        :type label: str
+        :param space_key: Restrict search to a space (optional).
+        :type space_key: str, optional
+        :param limit: Maximum number of results (default 25).
+        :type limit: int, optional
+        :return: A SimpleNamespace containing the matching content.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = "/rest/api/content"
+        params: dict = {"label": label, "type": "page", "limit": limit}
+        if space_key:
+            params["spaceKey"] = space_key
+        return self.get(url, params=params)

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from types import SimpleNamespace
 
 from atlassian.client import AtlassianAPI
@@ -14,7 +15,41 @@ class Jira(AtlassianAPI):
 
     .. seealso::
         `JIRA REST API Documentation <https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/>`_
+
+    Agile methods (``get_boards``, ``get_board``, ``get_sprints``, etc.) require a
+    Jira Software license and use the ``/rest/agile/1.0/`` base path.
     """
+
+    @property
+    def _agile_url(self) -> str:
+        """Base URL for the Jira Software Agile REST API."""
+        return self.url + "/rest/agile/1.0"
+
+    def _paged_post(self, url: str, body: dict, result_key: str = "issues") -> list:
+        """Paginate through POST-based Jira search endpoints.
+
+        Makes repeated POST requests incrementing ``startAt`` until all pages
+        are consumed.  Each iteration merges ``startAt`` into a copy of *body*
+        so the caller's dict is never mutated.
+
+        :param url: The search endpoint path.
+        :param body: Base request body (must not include ``startAt``).
+        :param result_key: Key in the response JSON that holds the result list.
+        :returns: Aggregated list of all items across pages.
+        """
+        results: list = []
+        start_at = 0
+        while True:
+            paged_body = {**body, "startAt": start_at}
+            response = self.post(url, json=paged_body) or {}
+            items = response.get(result_key, [])
+            results.extend(items)
+            total = response.get("total", 0)
+            max_results_per_page = response.get("maxResults", len(items))
+            start_at += max_results_per_page
+            if start_at >= total or not items:
+                break
+        return results
 
     def issue(self, issue_key: str) -> SimpleNamespace | str | None:
         """
@@ -263,6 +298,10 @@ class Jira(AtlassianAPI):
         """
         Create task issue.
 
+        .. deprecated::
+            Use :meth:`create_issue` instead. This method uses instance-specific
+            custom field IDs and will be removed in v1.0.
+
         :param project_key: The key of the project.
         :type project_key: str
         :param summary: The summary of the issue.
@@ -280,6 +319,12 @@ class Jira(AtlassianAPI):
         :return: The response from the API.
         :rtype: dict or None
         """
+        warnings.warn(
+            "create_task() is deprecated and will be removed in v1.0. "
+            "Use create_issue() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         url = "/rest/api/2/issue"
         json = {
             "fields": {
@@ -312,6 +357,10 @@ class Jira(AtlassianAPI):
         """
         Create sub task issue.
 
+        .. deprecated::
+            Use :meth:`create_issue` instead. This method uses instance-specific
+            custom field IDs and will be removed in v1.0.
+
         :param project_key: The key of the project.
         :type project_key: str
         :param parent_issue_key: The key of the parent issue.
@@ -333,6 +382,12 @@ class Jira(AtlassianAPI):
         :return: The response from the API.
         :rtype: dict or None
         """
+        warnings.warn(
+            "create_sub_task() is deprecated and will be removed in v1.0. "
+            "Use create_issue() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         url = "/rest/api/2/issue"
         json = {
             "fields": {
@@ -465,8 +520,8 @@ class Jira(AtlassianAPI):
             total = response["total"]
         except KeyError:
             return issues
-        max_results = response["maxResults"]
-        for issue in response["issues"]:
+        max_results = response.get("maxResults", max_result)
+        for issue in response.get("issues", []):
             issues.append(issue)
 
         while total > max_results:
@@ -479,7 +534,7 @@ class Jira(AtlassianAPI):
             }
             response = self.post(url, json=json) or {}
             total = total - max_results
-            for issue in response["issues"]:
+            for issue in response.get("issues", []):
                 issues.append(issue)
         return issues
 
@@ -527,3 +582,448 @@ class Jira(AtlassianAPI):
         """
         url = f"/rest/dev-status/1.0/issue/detail?issueId={issue_id}&applicationType={app_type}&dataType={data_type}"
         return self.get(url)
+
+    # ------------------------------------------------------------------ #
+    # Agile (Jira Software) — requires /rest/agile/1.0/ and Jira Software #
+    # ------------------------------------------------------------------ #
+
+    def get_boards(
+        self,
+        project_key: str | None = None,
+        board_type: str | None = None,
+    ) -> SimpleNamespace | str | None:
+        """
+        Get all boards, optionally filtered by project or type.
+
+        :param project_key: Filter boards by project key or ID.
+        :type project_key: str, optional
+        :param board_type: Filter by board type (``scrum`` or ``kanban``).
+        :type board_type: str, optional
+        :return: A SimpleNamespace containing the list of boards.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"{self._agile_url}/board"
+        params: dict = {}
+        if project_key:
+            params["projectKeyOrId"] = project_key
+        if board_type:
+            params["type"] = board_type
+        return self.get(url, params=params or None)
+
+    def get_board(self, board_id: int) -> SimpleNamespace | str | None:
+        """
+        Get a single board by ID.
+
+        :param board_id: The ID of the board.
+        :type board_id: int
+        :return: A SimpleNamespace containing the board details.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"{self._agile_url}/board/{board_id}"
+        return self.get(url)
+
+    def get_sprints(
+        self,
+        board_id: int,
+        state: str | None = None,
+    ) -> SimpleNamespace | str | None:
+        """
+        Get sprints for a board.
+
+        :param board_id: The ID of the board.
+        :type board_id: int
+        :param state: Filter by state: ``future``, ``active``, or ``closed``.
+        :type state: str, optional
+        :return: A SimpleNamespace containing the list of sprints.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"{self._agile_url}/board/{board_id}/sprint"
+        params: dict = {}
+        if state:
+            params["state"] = state
+        return self.get(url, params=params or None)
+
+    def get_active_sprint(self, board_id: int) -> SimpleNamespace | str | None:
+        """
+        Get the active sprint for a board.
+
+        Convenience wrapper around :meth:`get_sprints` with ``state="active"``.
+
+        :param board_id: The ID of the board.
+        :type board_id: int
+        :return: A SimpleNamespace containing the active sprint(s).
+        :rtype: SimpleNamespace or str or None
+        """
+        return self.get_sprints(board_id, state="active")
+
+    def get_sprint_issues(
+        self, sprint_id: int, max_results: int = 50
+    ) -> SimpleNamespace | str | None:
+        """
+        Get issues in a sprint.
+
+        :param sprint_id: The ID of the sprint.
+        :type sprint_id: int
+        :param max_results: Maximum number of issues to return (default 50).
+        :type max_results: int, optional
+        :return: A SimpleNamespace containing the issues.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"{self._agile_url}/sprint/{sprint_id}/issue"
+        return self.get(url, params={"maxResults": max_results})
+
+    def create_sprint(
+        self,
+        board_id: int,
+        name: str,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        goal: str | None = None,
+    ) -> dict | None:
+        """
+        Create a sprint on a board.
+
+        :param board_id: The ID of the origin board.
+        :type board_id: int
+        :param name: The name of the new sprint.
+        :type name: str
+        :param start_date: ISO 8601 start date (optional).
+        :type start_date: str, optional
+        :param end_date: ISO 8601 end date (optional).
+        :type end_date: str, optional
+        :param goal: Sprint goal text (optional).
+        :type goal: str, optional
+        :return: The created sprint object.
+        :rtype: dict or None
+        """
+        url = f"{self._agile_url}/sprint"
+        payload: dict = {"name": name, "originBoardId": board_id}
+        if start_date:
+            payload["startDate"] = start_date
+        if end_date:
+            payload["endDate"] = end_date
+        if goal:
+            payload["goal"] = goal
+        return self.post(url, json=payload)
+
+    def update_sprint(
+        self,
+        sprint_id: int,
+        state: str,
+        name: str | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        goal: str | None = None,
+    ) -> dict | None:
+        """
+        Update a sprint.
+
+        :param sprint_id: The ID of the sprint.
+        :type sprint_id: int
+        :param state: New state — must be ``"future"``, ``"active"``, or ``"closed"``.
+        :type state: str
+        :param name: New sprint name (optional).
+        :type name: str, optional
+        :param start_date: ISO 8601 start date (optional).
+        :type start_date: str, optional
+        :param end_date: ISO 8601 end date (optional).
+        :type end_date: str, optional
+        :param goal: Sprint goal text (optional).
+        :type goal: str, optional
+        :return: The updated sprint object.
+        :rtype: dict or None
+        :raises ValueError: If *state* is not one of the valid values.
+        """
+        valid_states = ("future", "active", "closed")
+        if state not in valid_states:
+            raise ValueError(f"state must be one of {valid_states}, got {state!r}")
+        url = f"{self._agile_url}/sprint/{sprint_id}"
+        payload: dict = {"state": state}
+        if name:
+            payload["name"] = name
+        if start_date:
+            payload["startDate"] = start_date
+        if end_date:
+            payload["endDate"] = end_date
+        if goal:
+            payload["goal"] = goal
+        return self.put(url, json=payload)
+
+    # ------------------------------------------------------------------ #
+    # Projects                                                             #
+    # ------------------------------------------------------------------ #
+
+    def get_project(self, project_key: str) -> SimpleNamespace | str | None:
+        """
+        Get a project by key or ID.
+
+        :param project_key: The project key or ID.
+        :type project_key: str
+        :return: A SimpleNamespace containing the project details.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"/rest/api/2/project/{project_key}"
+        return self.get(url)
+
+    def list_projects(self) -> SimpleNamespace | str | None:
+        """
+        List all projects visible to the current user.
+
+        :return: A SimpleNamespace containing the list of projects.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = "/rest/api/2/project"
+        return self.get(url)
+
+    def create_project(
+        self,
+        key: str,
+        name: str,
+        project_type_key: str,
+        lead: str | None = None,
+        description: str | None = None,
+    ) -> dict | None:
+        """
+        Create a new project.
+
+        :param key: The project key (e.g. ``"MYPROJ"``).
+        :type key: str
+        :param name: The display name of the project.
+        :type name: str
+        :param project_type_key: Project type (e.g. ``"software"``, ``"business"``).
+        :type project_type_key: str
+        :param lead: Username of the project lead (optional).
+        :type lead: str, optional
+        :param description: Project description (optional).
+        :type description: str, optional
+        :return: The created project object.
+        :rtype: dict or None
+        """
+        url = "/rest/api/2/project"
+        payload: dict = {"key": key, "name": name, "projectTypeKey": project_type_key}
+        if lead:
+            payload["lead"] = lead
+        if description:
+            payload["description"] = description
+        return self.post(url, json=payload)
+
+    def delete_project(self, project_key: str) -> dict | None:
+        """
+        Delete a project.
+
+        :param project_key: The project key or ID.
+        :type project_key: str
+        :return: The response from the API.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/2/project/{project_key}"
+        return self.delete(url)
+
+    # ------------------------------------------------------------------ #
+    # Attachments                                                          #
+    # ------------------------------------------------------------------ #
+
+    def add_attachment(
+        self,
+        issue_key: str,
+        file_path: str,
+        mime_type: str = "application/octet-stream",
+    ) -> dict | None:
+        """
+        Attach a file to an issue.
+
+        :param issue_key: The issue key (e.g. ``"TEST-1"``).
+        :type issue_key: str
+        :param file_path: Path to the local file to attach.
+        :type file_path: str
+        :param mime_type: MIME type of the file (default ``application/octet-stream``).
+        :type mime_type: str, optional
+        :return: The attachment metadata returned by the API.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/2/issue/{issue_key}/attachments"
+        return self.upload(url, file_path, mime_type)
+
+    def get_attachments(self, issue_key: str) -> SimpleNamespace | str | None:
+        """
+        Get attachments for an issue.
+
+        :param issue_key: The issue key.
+        :type issue_key: str
+        :return: A SimpleNamespace containing attachment metadata.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"/rest/api/2/issue/{issue_key}?fields=attachment"
+        return self.get(url)
+
+    def delete_attachment(self, attachment_id: str) -> dict | None:
+        """
+        Delete an attachment by ID.
+
+        :param attachment_id: The ID of the attachment.
+        :type attachment_id: str
+        :return: The response from the API.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/2/attachment/{attachment_id}"
+        return self.delete(url)
+
+    # ------------------------------------------------------------------ #
+    # Worklogs                                                             #
+    # ------------------------------------------------------------------ #
+
+    def add_worklog(
+        self,
+        issue_key: str,
+        time_spent: str,
+        started: str | None = None,
+        comment: str | None = None,
+    ) -> dict | None:
+        """
+        Add a worklog entry to an issue.
+
+        :param issue_key: The issue key.
+        :type issue_key: str
+        :param time_spent: Time spent in Jira notation (e.g. ``"2h 30m"``).
+        :type time_spent: str
+        :param started: ISO 8601 datetime when the work started (optional).
+        :type started: str, optional
+        :param comment: Worklog comment (optional).
+        :type comment: str, optional
+        :return: The created worklog object.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/2/issue/{issue_key}/worklog"
+        payload: dict = {"timeSpent": time_spent}
+        if started:
+            payload["started"] = started
+        if comment:
+            payload["comment"] = comment
+        return self.post(url, json=payload)
+
+    def get_worklogs(self, issue_key: str) -> SimpleNamespace | str | None:
+        """
+        Get worklog entries for an issue.
+
+        :param issue_key: The issue key.
+        :type issue_key: str
+        :return: A SimpleNamespace containing the worklogs.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"/rest/api/2/issue/{issue_key}/worklog"
+        return self.get(url)
+
+    def delete_worklog(self, issue_key: str, worklog_id: str) -> dict | None:
+        """
+        Delete a worklog entry.
+
+        :param issue_key: The issue key.
+        :type issue_key: str
+        :param worklog_id: The ID of the worklog entry to delete.
+        :type worklog_id: str
+        :return: The response from the API.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/2/issue/{issue_key}/worklog/{worklog_id}"
+        return self.delete(url)
+
+    # ------------------------------------------------------------------ #
+    # Versions                                                             #
+    # ------------------------------------------------------------------ #
+
+    def get_versions(self, project_key: str) -> SimpleNamespace | str | None:
+        """
+        Get all versions for a project.
+
+        :param project_key: The project key or ID.
+        :type project_key: str
+        :return: A SimpleNamespace containing the list of versions.
+        :rtype: SimpleNamespace or str or None
+        """
+        url = f"/rest/api/2/project/{project_key}/versions"
+        return self.get(url)
+
+    def create_version(
+        self,
+        project_key: str,
+        name: str,
+        description: str | None = None,
+        released: bool = False,
+        archived: bool = False,
+    ) -> dict | None:
+        """
+        Create a project version.
+
+        :param project_key: The project key.
+        :type project_key: str
+        :param name: The version name.
+        :type name: str
+        :param description: Version description (optional).
+        :type description: str, optional
+        :param released: Whether the version is released (default False).
+        :type released: bool, optional
+        :param archived: Whether the version is archived (default False).
+        :type archived: bool, optional
+        :return: The created version object.
+        :rtype: dict or None
+        """
+        url = "/rest/api/2/version"
+        payload: dict = {
+            "name": name,
+            "project": project_key,
+            "released": released,
+            "archived": archived,
+        }
+        if description:
+            payload["description"] = description
+        return self.post(url, json=payload)
+
+    def update_version(
+        self,
+        version_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        released: bool | None = None,
+        archived: bool | None = None,
+    ) -> dict | None:
+        """
+        Update a project version.
+
+        Only provided fields are updated.
+
+        :param version_id: The ID of the version.
+        :type version_id: str
+        :param name: New version name (optional).
+        :type name: str, optional
+        :param description: New description (optional).
+        :type description: str, optional
+        :param released: Update released flag (optional).
+        :type released: bool, optional
+        :param archived: Update archived flag (optional).
+        :type archived: bool, optional
+        :return: The updated version object.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/2/version/{version_id}"
+        payload: dict = {}
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+        if released is not None:
+            payload["released"] = released
+        if archived is not None:
+            payload["archived"] = archived
+        return self.put(url, json=payload)
+
+    def delete_version(self, version_id: str) -> dict | None:
+        """
+        Delete a project version.
+
+        :param version_id: The ID of the version.
+        :type version_id: str
+        :return: The response from the API.
+        :rtype: dict or None
+        """
+        url = f"/rest/api/2/version/{version_id}"
+        return self.delete(url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     {email = "xianpeng.shen@gmail.com"},
 ]
 dependencies = [
-    "requests"
+    "requests>=2.25.0"
 ]
 requires-python = ">=3.9"
 dynamic = ["version"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -353,3 +353,130 @@ class TestAtlassianAPI:
 
         assert exc_info.value.code == 403
         assert '{"message": "You do not have permission"}' in exc_info.value.message
+
+    # ------------------------------------------------------------------ #
+    # Network error wrapping                                               #
+    # ------------------------------------------------------------------ #
+
+    def test_request_wraps_connection_error_as_api_error(self):
+        api = AtlassianAPI(url="https://example.com")
+        api._session.request = MagicMock(
+            side_effect=requests.exceptions.ConnectionError("refused")
+        )
+        with pytest.raises(APIError) as exc_info:
+            api.request(method="GET", path="/api/test")
+        assert exc_info.value.code == -1
+        assert "refused" in exc_info.value.message
+
+    def test_request_wraps_timeout_error_as_api_error(self):
+        api = AtlassianAPI(url="https://example.com")
+        api._session.request = MagicMock(
+            side_effect=requests.exceptions.Timeout("timed out")
+        )
+        with pytest.raises(APIError) as exc_info:
+            api.request(method="GET", path="/api/test")
+        assert exc_info.value.code == -1
+
+    def test_request_wraps_ssl_error_as_api_error(self):
+        api = AtlassianAPI(url="https://example.com")
+        api._session.request = MagicMock(
+            side_effect=requests.exceptions.SSLError("cert verify failed")
+        )
+        with pytest.raises(APIError) as exc_info:
+            api.request(method="GET", path="/api/test")
+        assert exc_info.value.code == -1
+
+    # ------------------------------------------------------------------ #
+    # max_retries / HTTPAdapter                                            #
+    # ------------------------------------------------------------------ #
+
+    def test_max_retries_mounts_https_adapter(self):
+        api = AtlassianAPI(url="https://example.com", max_retries=3)
+        from requests.adapters import HTTPAdapter
+
+        adapter = api._session.get_adapter("https://example.com")
+        assert isinstance(adapter, HTTPAdapter)
+        assert adapter.max_retries.total == 3
+
+    def test_max_retries_mounts_http_adapter(self):
+        api = AtlassianAPI(url="http://example.com", max_retries=2)
+        from requests.adapters import HTTPAdapter
+
+        adapter = api._session.get_adapter("http://example.com")
+        assert isinstance(adapter, HTTPAdapter)
+        assert adapter.max_retries.total == 2
+
+    def test_zero_max_retries_uses_default_adapter(self):
+        # When max_retries=0 (default), no custom HTTPAdapter should be mounted.
+        # The default requests HTTPAdapter has max_retries.total == 0.
+        api = AtlassianAPI(url="https://example.com")
+        from requests.adapters import HTTPAdapter
+
+        adapter = api._session.get_adapter("https://example.com")
+        assert isinstance(adapter, HTTPAdapter)
+        assert adapter.max_retries.total == 0
+
+    # ------------------------------------------------------------------ #
+    # files= forwarding in request()                                       #
+    # ------------------------------------------------------------------ #
+
+    def test_request_forwards_files_kwarg(self):
+        api = AtlassianAPI(url="https://example.com")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.reason = "OK"
+        api._session.request = MagicMock(return_value=mock_response)
+
+        fake_files = {"file": ("name.txt", b"content", "text/plain")}
+        api.request(method="POST", path="/api/upload", files=fake_files)
+
+        call_kwargs = api._session.request.call_args[1]
+        assert call_kwargs["files"] == fake_files
+
+    def test_request_does_not_forward_files_when_none(self):
+        api = AtlassianAPI(url="https://example.com")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.reason = "OK"
+        api._session.request = MagicMock(return_value=mock_response)
+
+        api.request(method="GET", path="/api/test")
+
+        call_kwargs = api._session.request.call_args[1]
+        assert "files" not in call_kwargs
+
+    # ------------------------------------------------------------------ #
+    # upload()                                                             #
+    # ------------------------------------------------------------------ #
+
+    def test_upload_sends_x_atlassian_token_header(self, tmp_path):
+        api = AtlassianAPI(url="https://example.com")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.reason = "OK"
+        mock_response.json.return_value = [{"id": "1"}]
+        api._session.request = MagicMock(return_value=mock_response)
+
+        test_file = tmp_path / "attachment.txt"
+        test_file.write_bytes(b"hello")
+
+        api.upload("/rest/api/2/issue/TEST-1/attachments", str(test_file))
+
+        call_kwargs = api._session.request.call_args[1]
+        assert call_kwargs["headers"]["X-Atlassian-Token"] == "nocheck"
+
+    def test_upload_sends_file_content(self, tmp_path):
+        api = AtlassianAPI(url="https://example.com")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.reason = "OK"
+        mock_response.json.return_value = [{"id": "1"}]
+        api._session.request = MagicMock(return_value=mock_response)
+
+        test_file = tmp_path / "data.txt"
+        test_file.write_bytes(b"test content")
+
+        api.upload("/rest/api/upload", str(test_file))
+
+        call_kwargs = api._session.request.call_args[1]
+        assert "files" in call_kwargs

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -47,11 +47,13 @@ class TestConfluence:
         )
 
     def test_update_content(self, confluence):
+        # get_content_version calls get_content_history internally; mock it directly
+        confluence.get_content_version = MagicMock(return_value=5)
         confluence.update_content(123, "Test Page", "Body Value")
         confluence.put.assert_called_with(
             "/rest/api/content/123",
             json={
-                "version": {"number": 2},
+                "version": {"number": 6},
                 "title": "Test Page",
                 "type": "page",
                 "body": {
@@ -59,6 +61,13 @@ class TestConfluence:
                 },
             },
         )
+
+    def test_update_content_version_fetch_failure_raises(self, confluence):
+        from atlassian.error import APIError
+
+        confluence.get_content_version = MagicMock(return_value=None)
+        with pytest.raises(APIError):
+            confluence.update_content(999, "Title", "Body")
 
     def test_delete_content(self, confluence):
         confluence.delete_content(123)
@@ -71,3 +80,155 @@ class TestConfluence:
     def test_get_content_history(self, confluence):
         confluence.get_content_history(123)
         confluence.get.assert_called_with("/rest/api/content/123/history")
+
+    def test_get_content_version_returns_number(self, confluence):
+        from types import SimpleNamespace
+
+        mock_history = SimpleNamespace(lastUpdated=SimpleNamespace(number=7))
+        confluence.get = MagicMock(return_value=mock_history)
+        result = confluence.get_content_version(123)
+        assert result == 7
+
+    def test_get_content_version_returns_none_on_missing_attr(self, confluence):
+        from types import SimpleNamespace
+
+        confluence.get = MagicMock(return_value=SimpleNamespace())
+        result = confluence.get_content_version(123)
+        assert result is None
+
+    def test_get_content_version_returns_none_on_none_response(self, confluence):
+        confluence.get = MagicMock(return_value=None)
+        result = confluence.get_content_version(123)
+        assert result is None
+
+    # ------------------------------------------------------------------ #
+    # Search & spaces                                                      #
+    # ------------------------------------------------------------------ #
+
+    def test_search_content(self, confluence):
+        confluence.search_content('type=page AND space="TS"')
+        confluence.get.assert_called_with(
+            "/rest/api/content/search",
+            params={"cql": 'type=page AND space="TS"', "limit": 25},
+        )
+
+    def test_get_space(self, confluence):
+        confluence.get_space("MYSPACE")
+        confluence.get.assert_called_with("/rest/api/space/MYSPACE")
+
+    def test_list_spaces(self, confluence):
+        confluence.list_spaces()
+        confluence.get.assert_called_with("/rest/api/space", params={"limit": 25})
+
+    # ------------------------------------------------------------------ #
+    # Page hierarchy                                                       #
+    # ------------------------------------------------------------------ #
+
+    def test_get_page_children(self, confluence):
+        confluence.get_page_children(123)
+        confluence.get.assert_called_with("/rest/api/content/123/child/page")
+
+    def test_get_page_ancestors(self, confluence):
+        confluence.get_page_ancestors(123)
+        confluence.get.assert_called_with("/rest/api/content/123/ancestor")
+
+    def test_move_page_append(self, confluence):
+        confluence.move_page(10, 20)
+        confluence.put.assert_called_with("/rest/api/content/10/move/append/20")
+
+    def test_move_page_before(self, confluence):
+        confluence.move_page(10, 20, position="before")
+        confluence.put.assert_called_with("/rest/api/content/10/move/before/20")
+
+    def test_move_page_invalid_position_raises(self, confluence):
+        with pytest.raises(ValueError):
+            confluence.move_page(10, 20, position="invalid")
+
+    # ------------------------------------------------------------------ #
+    # Attachments                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_get_attachments(self, confluence):
+        confluence.get_attachments(123)
+        confluence.get.assert_called_with("/rest/api/content/123/child/attachment")
+
+    def test_delete_attachment(self, confluence):
+        confluence.delete_attachment("att-456")
+        confluence.delete.assert_called_with("/rest/api/content/att-456")
+
+    def test_add_attachment(self, confluence):
+        confluence.upload = MagicMock(return_value={"id": "1"})
+        confluence.add_attachment(123, "/tmp/file.txt")
+        confluence.upload.assert_called_with(
+            "/rest/api/content/123/child/attachment",
+            "/tmp/file.txt",
+            "application/octet-stream",
+        )
+
+    # ------------------------------------------------------------------ #
+    # Labels                                                               #
+    # ------------------------------------------------------------------ #
+
+    def test_get_labels(self, confluence):
+        confluence.get_labels(123)
+        confluence.get.assert_called_with("/rest/api/content/123/label")
+
+    def test_add_label(self, confluence):
+        confluence.add_label(123, "my-label")
+        confluence.post.assert_called_with(
+            "/rest/api/content/123/label",
+            json=[{"prefix": "global", "name": "my-label"}],
+        )
+
+    def test_remove_label(self, confluence):
+        confluence.remove_label(123, "my-label")
+        confluence.delete.assert_called_with(
+            "/rest/api/content/123/label", params={"name": "my-label"}
+        )
+
+    # ------------------------------------------------------------------ #
+    # Comments                                                             #
+    # ------------------------------------------------------------------ #
+
+    def test_get_comments(self, confluence):
+        confluence.get_comments(123)
+        confluence.get.assert_called_with("/rest/api/content/123/child/comment")
+
+    def test_add_comment(self, confluence):
+        confluence.add_comment(123, "<p>Hello</p>")
+        args, kwargs = confluence.post.call_args
+        assert args[0] == "/rest/api/content"
+        assert kwargs["json"]["type"] == "comment"
+        assert kwargs["json"]["container"]["id"] == 123
+        assert kwargs["json"]["body"]["storage"]["value"] == "<p>Hello</p>"
+
+    def test_delete_comment(self, confluence):
+        confluence.delete_comment(999)
+        confluence.delete.assert_called_with("/rest/api/content/999")
+
+    # ------------------------------------------------------------------ #
+    # Restrictions & discovery                                             #
+    # ------------------------------------------------------------------ #
+
+    def test_get_content_restrictions(self, confluence):
+        confluence.get_content_restrictions(123)
+        confluence.get.assert_called_with("/rest/api/content/123/restriction")
+
+    def test_get_content_by_title(self, confluence):
+        confluence.get_content_by_title("MYSPACE", "My Page")
+        confluence.get.assert_called_with(
+            "/rest/api/content",
+            params={"spaceKey": "MYSPACE", "title": "My Page", "type": "page"},
+        )
+
+    def test_search_content_by_label(self, confluence):
+        confluence.search_content_by_label("release-notes")
+        confluence.get.assert_called_with(
+            "/rest/api/content",
+            params={"label": "release-notes", "type": "page", "limit": 25},
+        )
+
+    def test_search_content_by_label_with_space(self, confluence):
+        confluence.search_content_by_label("release-notes", space_key="TS")
+        args, kwargs = confluence.get.call_args
+        assert kwargs["params"]["spaceKey"] == "TS"

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -292,3 +292,210 @@ class TestJira:
         jira.get.assert_called_with(
             "/rest/dev-status/1.0/issue/detail?issueId=12345&applicationType=custom&dataType=branch"
         )
+
+    # ------------------------------------------------------------------ #
+    # DeprecationWarning                                                   #
+    # ------------------------------------------------------------------ #
+
+    def test_create_task_emits_deprecation_warning(self, jira):
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            jira.create_task(project_key="PROJ", summary="s", assignee="a", owner="o")
+        assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_create_sub_task_emits_deprecation_warning(self, jira):
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            jira.create_sub_task(
+                project_key="PROJ",
+                parent_issue_key="PROJ-1",
+                summary="s",
+                fix_version="1.0",
+                assignee="a",
+                description="d",
+                labels=[],
+            )
+        assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    # ------------------------------------------------------------------ #
+    # _paged_post                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_paged_post_single_page(self, jira):
+        jira.post = MagicMock(
+            return_value={"values": [1, 2, 3], "total": 3, "maxResults": 50}
+        )
+        result = jira._paged_post(
+            "/rest/agile/1.0/board/1/sprint", {}, result_key="values"
+        )
+        assert result == [1, 2, 3]
+
+    def test_paged_post_multiple_pages(self, jira):
+        jira.post = MagicMock(
+            side_effect=[
+                {"values": list(range(50)), "total": 75, "maxResults": 50},
+                {"values": list(range(25)), "total": 75, "maxResults": 50},
+            ]
+        )
+        result = jira._paged_post(
+            "/rest/agile/1.0/board/1/sprint", {}, result_key="values"
+        )
+        assert len(result) == 75
+
+    def test_paged_post_empty_response(self, jira):
+        jira.post = MagicMock(return_value={"values": [], "total": 0, "maxResults": 50})
+        result = jira._paged_post(
+            "/rest/agile/1.0/board/1/sprint", {}, result_key="values"
+        )
+        assert result == []
+
+    # ------------------------------------------------------------------ #
+    # Agile                                                                #
+    # ------------------------------------------------------------------ #
+
+    def test_get_boards(self, jira):
+        jira.get_boards()
+        jira.get.assert_called_with(
+            "https://fake_url/rest/agile/1.0/board", params=None
+        )
+
+    def test_get_boards_with_project(self, jira):
+        jira.get_boards(project_key="PROJ")
+        args, kwargs = jira.get.call_args
+        assert kwargs["params"]["projectKeyOrId"] == "PROJ"
+
+    def test_get_board(self, jira):
+        jira.get_board(42)
+        jira.get.assert_called_with("https://fake_url/rest/agile/1.0/board/42")
+
+    def test_get_sprints(self, jira):
+        jira.get_sprints(1)
+        jira.get.assert_called_with(
+            "https://fake_url/rest/agile/1.0/board/1/sprint", params=None
+        )
+
+    def test_get_sprints_with_state(self, jira):
+        jira.get_sprints(1, state="active")
+        args, kwargs = jira.get.call_args
+        assert kwargs["params"]["state"] == "active"
+
+    def test_get_active_sprint(self, jira):
+        jira.get_active_sprint(1)
+        args, kwargs = jira.get.call_args
+        assert kwargs["params"]["state"] == "active"
+
+    def test_get_sprint_issues(self, jira):
+        jira.get_sprint_issues(10)
+        jira.get.assert_called_with(
+            "https://fake_url/rest/agile/1.0/sprint/10/issue",
+            params={"maxResults": 50},
+        )
+
+    def test_create_sprint(self, jira):
+        jira.create_sprint(1, "Sprint 1")
+        args, kwargs = jira.post.call_args
+        assert args[0] == "https://fake_url/rest/agile/1.0/sprint"
+        assert kwargs["json"]["name"] == "Sprint 1"
+        assert kwargs["json"]["originBoardId"] == 1
+
+    def test_update_sprint_valid_state(self, jira):
+        jira.update_sprint(5, "active")
+        args, kwargs = jira.put.call_args
+        assert args[0] == "https://fake_url/rest/agile/1.0/sprint/5"
+        assert kwargs["json"]["state"] == "active"
+
+    def test_update_sprint_invalid_state_raises(self, jira):
+        with pytest.raises(ValueError):
+            jira.update_sprint(5, "invalid")
+
+    # ------------------------------------------------------------------ #
+    # Projects                                                             #
+    # ------------------------------------------------------------------ #
+
+    def test_get_project(self, jira):
+        jira.get_project("PROJ")
+        jira.get.assert_called_with("/rest/api/2/project/PROJ")
+
+    def test_list_projects(self, jira):
+        jira.list_projects()
+        jira.get.assert_called_with("/rest/api/2/project")
+
+    def test_create_project(self, jira):
+        jira.create_project("NEWP", "New Project", "software")
+        args, kwargs = jira.post.call_args
+        assert args[0] == "/rest/api/2/project"
+        assert kwargs["json"]["key"] == "NEWP"
+        assert kwargs["json"]["projectTypeKey"] == "software"
+
+    def test_delete_project(self, jira):
+        jira.delete_project("OLDP")
+        jira.delete.assert_called_with("/rest/api/2/project/OLDP")
+
+    # ------------------------------------------------------------------ #
+    # Attachments                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_add_attachment(self, jira):
+        jira.upload = MagicMock(return_value=[{"id": "1"}])
+        jira.add_attachment("TEST-1", "/tmp/file.txt")
+        jira.upload.assert_called_with(
+            "/rest/api/2/issue/TEST-1/attachments",
+            "/tmp/file.txt",
+            "application/octet-stream",
+        )
+
+    def test_get_attachments(self, jira):
+        jira.get_attachments("TEST-1")
+        jira.get.assert_called_with("/rest/api/2/issue/TEST-1?fields=attachment")
+
+    def test_delete_attachment(self, jira):
+        jira.delete_attachment("att-123")
+        jira.delete.assert_called_with("/rest/api/2/attachment/att-123")
+
+    # ------------------------------------------------------------------ #
+    # Worklogs                                                             #
+    # ------------------------------------------------------------------ #
+
+    def test_add_worklog(self, jira):
+        jira.add_worklog("TEST-1", "2h")
+        args, kwargs = jira.post.call_args
+        assert args[0] == "/rest/api/2/issue/TEST-1/worklog"
+        assert kwargs["json"]["timeSpent"] == "2h"
+
+    def test_get_worklogs(self, jira):
+        jira.get_worklogs("TEST-1")
+        jira.get.assert_called_with("/rest/api/2/issue/TEST-1/worklog")
+
+    def test_delete_worklog(self, jira):
+        jira.delete_worklog("TEST-1", "wl-99")
+        jira.delete.assert_called_with("/rest/api/2/issue/TEST-1/worklog/wl-99")
+
+    # ------------------------------------------------------------------ #
+    # Versions                                                             #
+    # ------------------------------------------------------------------ #
+
+    def test_get_versions(self, jira):
+        jira.get_versions("PROJ")
+        jira.get.assert_called_with("/rest/api/2/project/PROJ/versions")
+
+    def test_create_version(self, jira):
+        jira.create_version("PROJ", "1.0.0")
+        args, kwargs = jira.post.call_args
+        assert args[0] == "/rest/api/2/version"
+        assert kwargs["json"]["name"] == "1.0.0"
+        assert kwargs["json"]["project"] == "PROJ"
+
+    def test_update_version(self, jira):
+        jira.update_version("v-1", name="1.0.1", released=True)
+        args, kwargs = jira.put.call_args
+        assert args[0] == "/rest/api/2/version/v-1"
+        assert kwargs["json"]["name"] == "1.0.1"
+        assert kwargs["json"]["released"] is True
+
+    def test_delete_version(self, jira):
+        jira.delete_version("v-1")
+        jira.delete.assert_called_with("/rest/api/2/version/v-1")


### PR DESCRIPTION
- client.py: max_retries + HTTPAdapter (http+https), RequestException→APIError(-1), files=/headers= params on request(), upload() method, Any type for json= in post()
- jira.py: fix search_issue_with_jql KeyError guards (.get), add _agile_url property, _paged_post() pagination helper, DeprecationWarning on create_task/create_sub_task, 21 new methods: Agile (7), Projects (4), Attachments (3), Worklogs (3), Versions (4)
- confluence.py: fix update_content hardcoded version=2 → get_content_version()+1, add get_content_version() method, 18 new methods: search, spaces, hierarchy, attachments, labels, comments, restrictions, discovery
- pyproject.toml: pin requests>=2.25.0
- tests: 214 passing — critical regression test_update_content rewritten,
  + 60 new tests across client/jira/confluence covering all new codepaths

<!-- readthedocs-preview atlassian-api-py start -->
----
📚 Documentation preview 📚: https://atlassian-api-py--71.org.readthedocs.build/

<!-- readthedocs-preview atlassian-api-py end -->