### PR TITLE
Improve onboarding docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,11 +36,21 @@ Python Wrapper for Atlassian REST API
 Overview
 --------
 
-A Python wrapper for the Atlassian REST API, supporting JIRA, Bitbucket, and Confluence.
+``atlassian-api-py`` is a small Python wrapper for Atlassian REST APIs.
+It provides ready-to-use clients for Jira, Bitbucket, and Confluence so you
+can automate common Atlassian tasks without rewriting endpoint and session
+handling code.
 
-It streamlines integration with Atlassian products.
+The clients are intentionally lightweight:
 
-📘 Documentation: `atlassian-api-py.readthedocs.io <https://atlassian-api-py.readthedocs.io/>`_
+* ``GET`` helpers return nested ``SimpleNamespace`` objects, so response fields
+  can be accessed with dot notation.
+* ``POST``, ``PUT``, and ``DELETE`` helpers return decoded JSON dictionaries
+  when the API returns JSON, or ``None`` for empty responses.
+* HTTP ``4xx`` and ``5xx`` responses raise ``APIError`` with the status code
+  and response body.
+
+Documentation: `atlassian-api-py.readthedocs.io <https://atlassian-api-py.readthedocs.io/>`_
 
 .. end-overview
 
@@ -49,24 +59,55 @@ It streamlines integration with Atlassian products.
 Installation
 ------------
 
-To install the package, run the following command:
+Python 3.9 or newer is required.
+
+Install from PyPI:
 
 .. code-block:: bash
 
-   $ pip install atlassian-api-py
+   pip install atlassian-api-py
 
-To upgrade to the latest version, use:
+Upgrade an existing installation:
 
 .. code-block:: bash
 
-   $ pip install atlassian-api-py --upgrade
+   pip install --upgrade atlassian-api-py
 
 .. end-install
+
+Quick Start
+-----------
+
+Create a client for the Atlassian product you want to automate, then call the
+method that matches the operation.
+
+.. code-block:: python
+
+   from atlassian import Jira
+
+   jira = Jira(
+       url="https://jira.company.com",
+       username="your_username",
+       password="your_password",
+   )
+
+   issue = jira.issue("TEST-1")
+   print(f"{issue.key}: {issue.fields.summary}")
+
+Use a token instead of username/password when your Atlassian instance supports
+bearer token authentication:
+
+.. code-block:: python
+
+   from atlassian import Jira
+
+   jira = Jira(url="https://jira.company.com", token="your_token")
 
 Usage
 -----
 
-You can authenticate using either username/password or a personal access token. Credentials can be provided directly or loaded from a configuration file.
+You can authenticate with username/password or a token. Pass only the
+credential type supported by your Atlassian instance.
 
 Using username and password
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -74,7 +115,12 @@ Using username and password
 .. code-block:: python
 
    from atlassian import Jira
-   jira = Jira(url='https://jira.company.com', username="your_username", password="your_password")
+
+   jira = Jira(
+       url="https://jira.company.com",
+       username="your_username",
+       password="your_password",
+   )
 
 Using a token
 ~~~~~~~~~~~~~
@@ -82,9 +128,14 @@ Using a token
 .. code-block:: python
 
    from atlassian import Jira
-   jira = Jira(url='https://jira.company.com', token="your_token")
 
-Alternatively, load credentials from ``config.ini`` file:
+   jira = Jira(url="https://jira.company.com", token="your_token")
+
+Loading credentials from a file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For scripts, keep credentials outside your source code. One simple option is a
+local ``config.ini`` file that is excluded from version control.
 
 .. code-block:: ini
 
@@ -98,19 +149,24 @@ Alternatively, load credentials from ``config.ini`` file:
 .. code-block:: python
 
    import configparser
+
+   from atlassian import Jira
+
    config = configparser.ConfigParser()
    config.read('config.ini')
+   section = config["jira"]
 
-   jira_url = config['jira']['url']
-   jira_usr = config['jira']['username']
-   jira_psw = config['jira']['password']
-   # Alternatively
-   jira_token = config['jira']['token']
+   jira = Jira(
+       url=section["url"],
+       username=section.get("username"),
+       password=section.get("password"),
+       token=section.get("token"),
+   )
 
-Jira Usage
-~~~~~~~~~~
+Common Jira tasks
+~~~~~~~~~~~~~~~~~
 
-Getting issue fields
+Read issue fields:
 
 .. code-block:: python
 
@@ -119,16 +175,103 @@ Getting issue fields
    print(issue.fields.description)      # e.g. "This is a demo Jira ticket"
    print(issue.fields.issuetype.name)   # e.g. "Bug"
 
-Get additional issue details
+Update an issue:
 
 .. code-block:: python
 
-   print(issue.id)                      # e.g. 1684517
-   print(issue.key)                     # e.g. "TEST-1"
-   print(issue.fields.assignee.key)     # e.g. "xpshen"
-   print(issue.fields.summary)          # e.g. "Jira REST API Unit Test Example"
+   jira.update_issue_label("TEST-1", add_labels=["automation"])
+   jira.add_issue_comment("TEST-1", "Checked by an automation script.")
 
-More about Jira, Bitbucket, and Confluence API usage can be found in the `documentation <https://atlassian-api-py.readthedocs.io/>`_
+Create an issue:
+
+.. code-block:: python
+
+   jira.create_issue(
+       fields={
+           "project": {"key": "TEST"},
+           "summary": "Created from atlassian-api-py",
+           "issuetype": {"name": "Task"},
+           "description": "This issue was created through the Jira REST API.",
+       }
+   )
+
+Common Bitbucket tasks
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from atlassian import Bitbucket
+
+   bitbucket = Bitbucket(
+       url="https://bitbucket.company.com",
+       username="your_username",
+       password="your_password",
+   )
+
+   repos = bitbucket.get_project_repo("PROJECT_KEY")
+   for repo in repos:
+       print(repo.name)
+
+   bitbucket.create_pull_request(
+       project_key="PROJECT_KEY",
+       repo_slug="repo_slug",
+       title="Add automation update",
+       from_branch="feature/automation",
+       to_branch="main",
+       reviewers=["reviewer_slug"],
+   )
+
+Common Confluence tasks
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from atlassian import Confluence
+
+   confluence = Confluence(
+       url="https://confluence.company.com",
+       username="your_username",
+       password="your_password",
+   )
+
+   page = confluence.get_content_by_id(123456)
+   print(page.title)
+
+   confluence.create_content(
+       title="Automation Notes",
+       space_key="SPACE",
+       body_value="<p>Created from atlassian-api-py.</p>",
+   )
+
+Response handling
+~~~~~~~~~~~~~~~~~
+
+``GET`` responses are parsed into nested ``SimpleNamespace`` objects when the
+response body contains JSON:
+
+.. code-block:: python
+
+   issue = jira.issue("TEST-1")
+   print(issue.fields.status.name)
+
+If a response body is not JSON, the raw response text is returned. Empty
+responses return ``None``. Mutating methods such as ``post()``, ``put()``, and
+``delete()`` return a decoded dictionary when JSON is available.
+
+Use ``APIError`` to handle unsuccessful HTTP responses:
+
+.. code-block:: python
+
+   from atlassian.error import APIError
+
+   try:
+       jira.issue("MISSING-1")
+   except APIError as exc:
+       print(exc.code)
+       print(exc.message)
+
+More Jira, Bitbucket, and Confluence examples are available in the
+`documentation <https://atlassian-api-py.readthedocs.io/>`_.
 
 .. start-license
 

--- a/atlassian/__init__.py
+++ b/atlassian/__init__.py
@@ -1,26 +1,17 @@
-"""
-Atlassian API Library
+"""Convenience imports for the Atlassian product clients.
 
-This module provides access to the main classes for interacting with Atlassian products.
+Import ``Jira``, ``Bitbucket``, and ``Confluence`` from this package instead of
+their individual modules when writing scripts.
 
-Available classes:
-
-* Jira: For interacting with Jira APIs.
-* Bitbucket: For interacting with Bitbucket APIs.
-* Confluence: For interacting with Confluence APIs.
-
-.. note::
-    Import these classes directly from this module for convenience.
-
-Example usage:
+Example:
 
 .. code-block:: python
 
     from atlassian import Jira, Bitbucket, Confluence
 
-    jira = Jira(url="https://jira.company.com", username="your_username", password="your_password")
+    jira = Jira(url="https://jira.company.com", token="your_token")
     bitbucket = Bitbucket(url="https://bitbucket.company.com", token="your_token")
-    confluence = Confluence(url="https://confluence.company.com", username="your_username", password="your_password")
+    confluence = Confluence(url="https://confluence.company.com", token="your_token")
 """
 
 from atlassian.jira import Jira

--- a/atlassian/bitbucket.py
+++ b/atlassian/bitbucket.py
@@ -10,22 +10,25 @@ logger = get_logger(__name__)
 
 
 class Bitbucket(AtlassianAPI):
-    """
-    Bitbucket API Reference
+    """Client for Bitbucket Server/Data Center REST API operations.
+
+    Use this class for project repositories, branches, commits, pull requests,
+    comments, build status, users, and tags. Methods that list Bitbucket
+    resources automatically follow paginated ``values`` responses.
 
     .. seealso::
         `Bitbucket REST API Documentation <https://docs.atlassian.com/bitbucket-server/rest/7.12.1/bitbucket-rest.html>`_
     """
 
     def _get_paged(self, url: str, params: dict) -> list:
-        """
-        Retrieve paginated results from the Bitbucket API.
+        """Collect all ``values`` from a paginated Bitbucket endpoint.
 
-        :param url: The API endpoint URL.
+        :param url: Endpoint path to request.
         :type url: str
         :param params: Query parameters for pagination.
         :type params: dict
-        :return: A list of paginated results.
+        :return: Combined values from each page. Returns an empty list when the
+            response is missing ``values`` or cannot be parsed.
         :rtype: list
         """
         response = self.get(url, params=params)
@@ -52,8 +55,7 @@ class Bitbucket(AtlassianAPI):
     def get_project_repo(
         self, project_key: str, start: int = 0, limit: int | None = None
     ) -> list:
-        """
-        Retrieve repositories for a specific project.
+        """Return repositories in a Bitbucket project.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -61,7 +63,7 @@ class Bitbucket(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (optional).
         :type limit: int, optional
-        :return: A list of repositories in the project.
+        :return: Repository objects from the paginated ``values`` response.
         :rtype: list
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/"
@@ -73,12 +75,11 @@ class Bitbucket(AtlassianAPI):
         return self._get_paged(url, params=params)
 
     def get_project_repo_name(self, project_key: str) -> list[str]:
-        """
-        Retrieve the names of all repositories in a project.
+        """Return repository names for a Bitbucket project.
 
         :param project_key: The key of the project.
         :type project_key: str
-        :return: A list of repository names.
+        :return: Repository names.
         :rtype: list
         """
         values = self.get_project_repo(project_key)
@@ -90,15 +91,15 @@ class Bitbucket(AtlassianAPI):
     def get_repo_info(
         self, project_key: str, repo_slug: str
     ) -> SimpleNamespace | str | None:
-        """
-        Retrieve information about a specific repository.
+        """Return metadata for a repository.
 
         :param project_key: The key of the project.
         :type project_key: str
         :param repo_slug: The slug of the repository.
         :type repo_slug: str
-        :return: A dictionary containing repository information.
-        :rtype: dict
+        :return: Repository data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
+        :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}"
         return self.get(url)
@@ -106,8 +107,7 @@ class Bitbucket(AtlassianAPI):
     def get_repo_branch(
         self, project_key: str, repo_slug: str, start: int = 0, limit: int | None = None
     ) -> list:
-        """
-        Retrieve branches for a specific repository.
+        """Return branches in a repository.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -117,7 +117,7 @@ class Bitbucket(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (optional).
         :type limit: int, optional
-        :return: A list of branches in the repository.
+        :return: Branch objects from the paginated ``values`` response.
         :rtype: list
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/branches"
@@ -131,8 +131,7 @@ class Bitbucket(AtlassianAPI):
     def create_branch(
         self, project_key: str, repo_slug: str, branch_name: str, start_point: str
     ) -> dict | None:
-        """
-        Create a new branch in a repository.
+        """Create a branch from an existing branch or commit.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -140,10 +139,10 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param branch_name: The name of the new branch.
         :type branch_name: str
-        :param start_point: The starting point for the branch (e.g., a commit hash or branch name).
+        :param start_point: Source branch name or commit hash.
         :type start_point: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when Bitbucket returns no body.
+        :rtype: dict or None
         """
         url = (
             f"/rest/branch-utils/1.0/projects/{project_key}/repos/{repo_slug}/branches"
@@ -154,8 +153,7 @@ class Bitbucket(AtlassianAPI):
     def delete_branch(
         self, project_key: str, repo_slug: str, branch_name: str, end_point: str
     ) -> dict | None:
-        """
-        Delete a branch from a repository.
+        """Delete a branch from a repository.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -163,10 +161,10 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param branch_name: The name of the branch to delete.
         :type branch_name: str
-        :param end_point: The endpoint for the branch deletion.
+        :param end_point: Current commit hash for the branch deletion request.
         :type end_point: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when Bitbucket returns no body.
+        :rtype: dict or None
         """
         url = f"/rest/branch-utils/latest/projects/{project_key}/repos/{repo_slug}/branches"
         payload = {"name": branch_name, "endPoint": end_point}
@@ -175,8 +173,7 @@ class Bitbucket(AtlassianAPI):
     def get_merged_branch(
         self, project_key: str, repo_slug: str, start: int = 0, limit: int | None = None
     ) -> list[str]:
-        """
-        Retrieve the names of merged branches in a repository.
+        """Return branch names that Bitbucket marks as merged.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -186,7 +183,7 @@ class Bitbucket(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (optional).
         :type limit: int, optional
-        :return: A list of merged branch names.
+        :return: Merged branch display names.
         :rtype: list
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/branches?base=refs/heads/master&details=true"
@@ -229,8 +226,7 @@ class Bitbucket(AtlassianAPI):
         start: int = 0,
         limit: int | None = None,
     ) -> list:
-        """
-        Get a specific branch commits.
+        """Return commits reachable from a branch.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -242,7 +238,7 @@ class Bitbucket(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (optional).
         :type limit: int, optional
-        :return: A list of commits in the branch.
+        :return: Commit objects from the paginated ``values`` response.
         :rtype: list
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/commits/?until={branch_name}"
@@ -261,10 +257,10 @@ class Bitbucket(AtlassianAPI):
         start: int = 0,
         limit: int | None = None,
     ) -> list:
-        """
-        Get ALL pull requests.
+        """Return pull requests for a repository.
 
-        By default: pr_state is ALL, other states are PEN, MERGED, DECLINED
+        Common ``pr_state`` values include ``ALL``, ``OPEN``, ``MERGED``, and
+        ``DECLINED``.
         :param project_key: The key of the project.
         :type project_key: str
         :param repo_slug: The slug of the repository.
@@ -275,7 +271,7 @@ class Bitbucket(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (optional).
         :type limit: int, optional
-        :return: A list of pull requests.
+        :return: Pull request objects from the paginated ``values`` response.
         :rtype: list
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests?state={pr_state}"
@@ -289,8 +285,7 @@ class Bitbucket(AtlassianAPI):
     def get_pull_request_destination_branch_name(
         self, project_key: str, repo_slug: str, pr_id: int, limit: int = 0
     ) -> str | None:
-        """
-        Get a pull request destination branch name.
+        """Return the destination branch name for a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -298,8 +293,10 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :return: The destination branch name associated with the pull request.
-        :rtype: str"""
+        :return: Destination branch name, or ``None`` when the pull request is
+            not found in the searched pages.
+        :rtype: str or None
+        """
         max_attempts = 100
         attempts = 0
         while attempts < max_attempts:
@@ -316,8 +313,7 @@ class Bitbucket(AtlassianAPI):
     def get_pull_request_source_branch_name(
         self, project_key: str, repo_slug: str, pr_id: int, limit: int = 0
     ) -> str | None:
-        """
-        Get a pull request source branch name.
+        """Return the source branch name for a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -325,8 +321,10 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :return: The source branch name associated with the pull request.
-        :rtype: str"""
+        :return: Source branch name, or ``None`` when the pull request is not
+            found in the searched pages.
+        :rtype: str or None
+        """
         max_attempts = 100
         attempts = 0
         while attempts < max_attempts:
@@ -343,8 +341,7 @@ class Bitbucket(AtlassianAPI):
     def get_pull_request_jira_key(
         self, project_key: str, repo_slug: str, pr_id: int
     ) -> str | None:
-        """
-        Get a pull request Jira ticket key.
+        """Extract a Jira issue key from a pull request source branch name.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -352,8 +349,9 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :return: The Jira ticket key associated with the pull request.
-        :rtype: str
+        :return: First ``PROJECT-123`` style key in the source branch, or
+            ``None`` when no key is found.
+        :rtype: str or None
         """
         source_branch_name = self.get_pull_request_source_branch_name(
             project_key, repo_slug, pr_id
@@ -373,10 +371,10 @@ class Bitbucket(AtlassianAPI):
         start: int = 0,
         limit: int | None = None,
     ) -> list[int]:
-        """
-        Get a specific pull request ID.
+        """Return pull request IDs for a repository and state.
 
-        By default: pr_state is OPEN, other states are ALL, MERGED, DECLINED
+        Common ``pr_state`` values include ``OPEN``, ``ALL``, ``MERGED``, and
+        ``DECLINED``.
         :param project_key: The key of the project.
         :type project_key: str
         :param repo_slug: The slug of the repository.
@@ -387,7 +385,7 @@ class Bitbucket(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (optional).
         :type limit: int, optional
-        :return: A list of pull request IDs.
+        :return: Pull request IDs.
         :rtype: list
         """
         prs = self.get_pull_request(
@@ -401,8 +399,7 @@ class Bitbucket(AtlassianAPI):
     def get_pull_request_overview(
         self, project_key: str, repo_slug: str, pr_id: int
     ) -> SimpleNamespace | str | None:
-        """
-        Get a specific pull request overview.
+        """Return pull request metadata.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -410,9 +407,8 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :return: The pull request overview as a :class:`SimpleNamespace` when the
-            response contains valid JSON, the raw response body as ``str`` when
-            JSON parsing fails, or ``None`` for an empty response.
+        :return: Pull request metadata as a ``SimpleNamespace``, raw response
+            text for non-JSON responses, or ``None`` for an empty body.
         :rtype: SimpleNamespace | str | None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}"
@@ -421,8 +417,7 @@ class Bitbucket(AtlassianAPI):
     def get_pull_request_diff(
         self, project_key: str, repo_slug: str, pr_id: int
     ) -> SimpleNamespace | str | None:
-        """
-        Get streams a diff within a pull request.
+        """Return the structured diff for a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -430,9 +425,8 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :return: The pull request diff as a :class:`SimpleNamespace` when the
-            response contains valid JSON, the raw response body as ``str`` when
-            JSON parsing fails, or ``None`` for an empty response.
+        :return: Diff data as a ``SimpleNamespace``, raw response text for
+            non-JSON responses, or ``None`` for an empty body.
         :rtype: SimpleNamespace | str | None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}/diff"
@@ -441,8 +435,7 @@ class Bitbucket(AtlassianAPI):
     def get_pull_request_raw_diff(
         self, project_key: str, repo_slug: str, pr_id: int
     ) -> SimpleNamespace | str | None:
-        """
-        Get streams the raw diff for a pull request.
+        """Return the raw unified diff for a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -450,8 +443,9 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :return: A string containing pull request diff information.
-        :rtype: str
+        :return: Raw diff text, parsed JSON if Bitbucket returns JSON, or
+            ``None`` for an empty body.
+        :rtype: SimpleNamespace | str | None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}.diff"
         return self.get(url)
@@ -459,8 +453,7 @@ class Bitbucket(AtlassianAPI):
     def get_pull_request_patch(
         self, project_key: str, repo_slug: str, pr_id: int
     ) -> SimpleNamespace | str | None:
-        """
-        Get streams a patch representing a pull request.
+        """Return the raw patch for a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -468,8 +461,9 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :return: A string containing pull request diff information.
-        :rtype: str
+        :return: Raw patch text, parsed JSON if Bitbucket returns JSON, or
+            ``None`` for an empty body.
+        :rtype: SimpleNamespace | str | None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}.patch"
         return self.get(url)
@@ -477,8 +471,7 @@ class Bitbucket(AtlassianAPI):
     def get_pull_request_commits(
         self, project_key: str, repo_slug: str, pr_id: int
     ) -> SimpleNamespace | str | None:
-        """
-        Get a specific pull request commits.
+        """Return commits in a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -486,9 +479,8 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :return: The parsed JSON response as a SimpleNamespace when available,
-            the raw string response when the body is not JSON, or None for an
-            empty response.
+        :return: Commit data as a ``SimpleNamespace``, raw response text for
+            non-JSON responses, or ``None`` for an empty body.
         :rtype: SimpleNamespace | str | None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}/commits"
@@ -502,8 +494,7 @@ class Bitbucket(AtlassianAPI):
         start: int = 0,
         limit: int | None = None,
     ) -> list:
-        """
-        Get a specific pull request activities information.
+        """Return activity entries for a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -515,7 +506,7 @@ class Bitbucket(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (optional).
         :type limit: int, optional
-        :return: A list of pull request activities.
+        :return: Activity objects from the paginated ``values`` response.
         :rtype: list
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}/activities"
@@ -529,8 +520,7 @@ class Bitbucket(AtlassianAPI):
     def get_pull_request_merge(
         self, project_key: str, repo_slug: str, pr_id: int
     ) -> SimpleNamespace | str | None:
-        """
-        Get the specific Pull Request merge information.
+        """Return mergeability information for a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -538,9 +528,8 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :return: Parsed pull request merge information as a ``SimpleNamespace`` when the
-            response body is valid JSON, the raw response body as ``str`` if JSON
-            parsing fails, or ``None`` for empty responses.
+        :return: Merge data as a ``SimpleNamespace``, raw response text for
+            non-JSON responses, or ``None`` for an empty body.
         :rtype: SimpleNamespace | str | None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}/merge"
@@ -554,8 +543,7 @@ class Bitbucket(AtlassianAPI):
         start: int = 0,
         limit: int | None = None,
     ) -> list:
-        """
-        Get branch committer information.
+        """Return committers for commits reachable from a branch.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -567,7 +555,7 @@ class Bitbucket(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (optional).
         :type limit: int, optional
-        :return: A list of committers in the branch.
+        :return: Committer objects extracted from branch commits.
         :rtype: list
         """
         commits = self.get_branch_commits(
@@ -581,8 +569,7 @@ class Bitbucket(AtlassianAPI):
     def get_pull_request_comments(
         self, project_key: str, repo_slug: str, pr_id: int
     ) -> SimpleNamespace | str | None:
-        """
-        Get a specific pull request all comments.
+        """Return comments for a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -590,8 +577,9 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :return: A list of comments in the pull request.
-        :rtype: list
+        :return: Comment data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
+        :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/ui/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}/comments"
         return self.get(url)
@@ -599,8 +587,7 @@ class Bitbucket(AtlassianAPI):
     def add_pull_request_comment(
         self, project_key: str, repo_slug: str, pr_id: int, comment: str
     ) -> dict | None:
-        """
-        Add comment to a specific pull request.
+        """Add a general comment to a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -610,8 +597,8 @@ class Bitbucket(AtlassianAPI):
         :type pr_id: int
         :param comment: The comment text.
         :type comment: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when Bitbucket returns no body.
+        :rtype: dict or None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}/comments"
         payload = {"text": comment}
@@ -629,8 +616,7 @@ class Bitbucket(AtlassianAPI):
         file_type: str = "TO",
         src_path: str | None = None,
     ) -> dict | None:
-        """
-        Add an inline comment to a specific file and line in a pull request.
+        """Add an inline comment to a file and line in a pull request diff.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -644,14 +630,15 @@ class Bitbucket(AtlassianAPI):
         :type path: str
         :param line: The line number in the file to comment on.
         :type line: int
-        :param line_type: The type of the line: CONTEXT, ADDED, or REMOVED (default: CONTEXT).
+        :param line_type: Diff line type: ``CONTEXT``, ``ADDED``, or
+            ``REMOVED``.
         :type line_type: str
-        :param file_type: The side of the diff: FROM or TO (default: TO).
+        :param file_type: Diff side: ``FROM`` or ``TO``.
         :type file_type: str
         :param src_path: The path of the file in the source commit (for renames).
         :type src_path: str, optional
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when Bitbucket returns no body.
+        :rtype: dict or None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}/comments"
         anchor: dict = {
@@ -673,8 +660,7 @@ class Bitbucket(AtlassianAPI):
         old_comment: str,
         new_comment: str,
     ) -> dict | None:
-        """
-        Update a specific comment of a pull request.
+        """Find a pull request comment by text and replace it.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -682,12 +668,13 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :param old_comment: The old comment text to be updated.
+        :param old_comment: Existing comment text to search for.
         :type old_comment: str
         :param new_comment: The new comment text.
         :type new_comment: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when no matching comment is
+            found or Bitbucket returns no body.
+        :rtype: dict or None
         """
         activities = self.get_pull_request_activities(project_key, repo_slug, pr_id)
         comment_id = version = severity = state = None
@@ -715,8 +702,7 @@ class Bitbucket(AtlassianAPI):
     def delete_pull_request_comment(
         self, project_key: str, repo_slug: str, pr_id: int, comment: str
     ) -> dict | None:
-        """
-        Delete comment from a specific pull request.
+        """Find a pull request comment by exact text and delete it.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -726,8 +712,9 @@ class Bitbucket(AtlassianAPI):
         :type pr_id: int
         :param comment: The comment text to be deleted.
         :type comment: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when no matching comment is
+            found or Bitbucket returns no body.
+        :rtype: dict or None
         """
         activities = self.get_pull_request_activities(project_key, repo_slug, pr_id)
         comment_id = version = None
@@ -783,8 +770,7 @@ class Bitbucket(AtlassianAPI):
     def resolve_pull_request_comment(
         self, project_key: str, repo_slug: str, pr_id: int, comment: str
     ) -> dict | None:
-        """
-        Resolve a blocker comment on a specific pull request.
+        """Mark a pull request comment task as resolved.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -792,10 +778,11 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :param comment: The comment text to be resolved.
+        :param comment: Comment text to search for.
         :type comment: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when no matching comment is
+            found or Bitbucket returns no body.
+        :rtype: dict or None
         """
         found = self._find_comment_in_activities(project_key, repo_slug, pr_id, comment)
         if not found:
@@ -812,8 +799,7 @@ class Bitbucket(AtlassianAPI):
     def reopen_pull_request_comment(
         self, project_key: str, repo_slug: str, pr_id: int, comment: str
     ) -> dict | None:
-        """
-        Reopen a resolved comment on a specific pull request.
+        """Reopen a resolved pull request comment task.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -821,10 +807,11 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :param comment: The comment text to be reopened.
+        :param comment: Comment text to search for.
         :type comment: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when no matching comment is
+            found or Bitbucket returns no body.
+        :rtype: dict or None
         """
         found = self._find_comment_in_activities(project_key, repo_slug, pr_id, comment)
         if not found:
@@ -841,8 +828,7 @@ class Bitbucket(AtlassianAPI):
     def convert_comment_to_task(
         self, project_key: str, repo_slug: str, pr_id: int, comment: str
     ) -> dict | None:
-        """
-        Convert a comment to a task (blocker) on a specific pull request.
+        """Convert a pull request comment into a blocker task.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -850,10 +836,11 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :param comment: The comment text to be converted to a task.
+        :param comment: Comment text to search for.
         :type comment: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when no matching comment is
+            found or Bitbucket returns no body.
+        :rtype: dict or None
         """
         found = self._find_comment_in_activities(project_key, repo_slug, pr_id, comment)
         if not found:
@@ -870,8 +857,7 @@ class Bitbucket(AtlassianAPI):
     def convert_task_to_comment(
         self, project_key: str, repo_slug: str, pr_id: int, comment: str
     ) -> dict | None:
-        """
-        Convert a task (blocker) back to a regular comment on a specific pull request.
+        """Convert a blocker task back to a regular pull request comment.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -879,10 +865,11 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :param comment: The comment text of the task to be converted to a comment.
+        :param comment: Comment text to search for.
         :type comment: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when no matching comment is
+            found or Bitbucket returns no body.
+        :rtype: dict or None
         """
         found = self._find_comment_in_activities(project_key, repo_slug, pr_id, comment)
         if not found:
@@ -905,8 +892,7 @@ class Bitbucket(AtlassianAPI):
         start: int = 0,
         limit: int | None = None,
     ) -> list:
-        """
-        Get a specific file change histories.
+        """Return commit history for a file on a branch.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -920,7 +906,7 @@ class Bitbucket(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (optional).
         :type limit: int, optional
-        :return: A list of file change histories.
+        :return: Commit history objects from the paginated ``values`` response.
         :rtype: list
         """
         url = (
@@ -937,8 +923,7 @@ class Bitbucket(AtlassianAPI):
     def get_file_content(
         self, project_key: str, repo_slug: str, branch_name: str, file_path: str
     ) -> SimpleNamespace | str | None:
-        """
-        Get file content from a specific branch.
+        """Return raw file content from a branch.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -948,20 +933,21 @@ class Bitbucket(AtlassianAPI):
         :type branch_name: str
         :param file_path: The path of the file.
         :type file_path: str
-        :return: The content of the file.
-        :rtype: str
+        :return: Raw file content, parsed JSON if Bitbucket returns JSON, or
+            ``None`` for an empty body.
+        :rtype: SimpleNamespace or str or None
         """
         url = f"/projects/{project_key}/repos/{repo_slug}/raw/{file_path}?at={branch_name}"
         return self.get(url)
 
     def get_build_status(self, commit_id: str) -> SimpleNamespace | str | None:
-        """
-        Get build status.
+        """Return build status for a commit.
 
         :param commit_id: The ID of the commit.
         :type commit_id: str
-        :return: A SimpleNamespace containing build status information.
-        :rtype: SimpleNamespace or None
+        :return: Build status data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
+        :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/build-status/latest/commits/{commit_id}"
         return self.get(url)
@@ -975,14 +961,14 @@ class Bitbucket(AtlassianAPI):
         build_url: str,
         description: str = "ManuallyCheckBuildPass",
     ) -> dict | None:
-        """
-        Update build status.
+        """Create or update Bitbucket build status for a commit.
 
         :param commit_id: The ID of the commit.
         :type commit_id: str
-        :param build_state: The state of the build.
+        :param build_state: Build state, for example ``SUCCESSFUL`` or
+            ``FAILED``.
         :type build_state: str
-        :param data_key: The key of the data.
+        :param data_key: Stable key identifying this build status.
         :type data_key: str
         :param build_name: The name of the build.
         :type build_name: str
@@ -990,7 +976,7 @@ class Bitbucket(AtlassianAPI):
         :type build_url: str
         :param description: The description of the build.
         :type description: str
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Bitbucket returns no body.
         :rtype: dict or None
         """
         url = f"/rest/build-status/latest/commits/{commit_id}"
@@ -1004,13 +990,13 @@ class Bitbucket(AtlassianAPI):
         return self.post(url, json=payload)
 
     def get_user(self, user_slug: str) -> SimpleNamespace | str | None:
-        """
-        Get user information.
+        """Return Bitbucket user information by user slug.
 
         :param user_slug: The slug of the user.
         :type user_slug: str
-        :return: A dictionary containing user information.
-        :rtype: dict
+        :return: User data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
+        :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/latest/users/{user_slug}"
         return self.get(url)
@@ -1023,8 +1009,7 @@ class Bitbucket(AtlassianAPI):
         user_slug: str,
         status: str = "APPROVED",
     ) -> dict | None:
-        """
-        Review a pull request as the current user.
+        """Set a user's review status on a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -1034,10 +1019,11 @@ class Bitbucket(AtlassianAPI):
         :type pr_id: int
         :param user_slug: The slug of the user.
         :type user_slug: str
-        :param status: The status of the review (default: APPROVED).
+        :param status: Review status. Common values are ``APPROVED``,
+            ``UNAPPROVED``, and ``NEEDS_WORK``.
         :type status: str, optional
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when Bitbucket returns no body.
+        :rtype: dict or None
         """
         url = f"/rest/api/1.0/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}/participants/{user_slug}"
         payload = {
@@ -1048,8 +1034,7 @@ class Bitbucket(AtlassianAPI):
     def update_pull_request_description(
         self, project_key: str, repo_slug: str, pr_id: int, new_description: str
     ) -> dict | None:
-        """
-        Update the description of a pull request.
+        """Replace a pull request description.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -1059,8 +1044,9 @@ class Bitbucket(AtlassianAPI):
         :type pr_id: int
         :param new_description: The new description for the pull request.
         :type new_description: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when the pull request cannot
+            be loaded or Bitbucket returns no body.
+        :rtype: dict or None
         """
         pr = self.get_pull_request_overview(project_key, repo_slug, pr_id)
         if pr is None or isinstance(pr, str):
@@ -1072,8 +1058,7 @@ class Bitbucket(AtlassianAPI):
     def update_pull_request_title(
         self, project_key: str, repo_slug: str, pr_id: int, new_title: str
     ) -> dict | None:
-        """
-        Update the title of a pull request.
+        """Replace a pull request title.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -1083,8 +1068,9 @@ class Bitbucket(AtlassianAPI):
         :type pr_id: int
         :param new_title: The new title for the pull request.
         :type new_title: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when the pull request cannot
+            be loaded or Bitbucket returns no body.
+        :rtype: dict or None
         """
         pr = self.get_pull_request_overview(project_key, repo_slug, pr_id)
         if pr is None or isinstance(pr, str):
@@ -1096,8 +1082,7 @@ class Bitbucket(AtlassianAPI):
     def update_pull_request_reviewers(
         self, project_key: str, repo_slug: str, pr_id: int, reviewers: list
     ) -> dict | None:
-        """
-        Update the reviewers of a pull request.
+        """Replace the reviewer list for a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -1105,10 +1090,11 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :param reviewers: A list of user slugs to add as reviewers.
+        :param reviewers: Reviewer payload expected by Bitbucket.
         :type reviewers: list
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when the pull request cannot
+            be loaded or Bitbucket returns no body.
+        :rtype: dict or None
         """
         pr = self.get_pull_request_overview(project_key, repo_slug, pr_id)
         if pr is None or isinstance(pr, str):
@@ -1120,8 +1106,7 @@ class Bitbucket(AtlassianAPI):
     def update_pull_request_destination(
         self, project_key: str, repo_slug: str, pr_id: int, new_destination: str
     ) -> dict | None:
-        """
-        Update the destination branch of a pull request.
+        """Change the destination branch of a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -1131,8 +1116,9 @@ class Bitbucket(AtlassianAPI):
         :type pr_id: int
         :param new_destination: The new destination branch for the pull request.
         :type new_destination: str
-        :return: The response from the API.
-        :rtype: dict
+        :return: Decoded API response, or ``None`` when the pull request cannot
+            be loaded or Bitbucket returns no body.
+        :rtype: dict or None
         """
         pr = self.get_pull_request_overview(project_key, repo_slug, pr_id)
         if pr is None or isinstance(pr, str):
@@ -1154,8 +1140,7 @@ class Bitbucket(AtlassianAPI):
         description: str | None = None,
         reviewers: list[str] | None = None,
     ) -> dict | None:
-        """
-        Create a new pull request.
+        """Create a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -1169,9 +1154,9 @@ class Bitbucket(AtlassianAPI):
         :type to_branch: str
         :param description: An optional description for the pull request.
         :type description: str, optional
-        :param reviewers: An optional list of reviewer user slugs.
+        :param reviewers: Optional reviewer user slugs.
         :type reviewers: list[str], optional
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Bitbucket returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests"
@@ -1189,8 +1174,7 @@ class Bitbucket(AtlassianAPI):
     def merge_pull_request(
         self, project_key: str, repo_slug: str, pr_id: int, pr_version: int
     ) -> dict | None:
-        """
-        Merge a pull request.
+        """Merge a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -1198,9 +1182,10 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :param pr_version: The current version of the pull request (required for optimistic locking).
+        :param pr_version: Current pull request version required by Bitbucket
+            optimistic locking.
         :type pr_version: int
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Bitbucket returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}/merge"
@@ -1210,8 +1195,7 @@ class Bitbucket(AtlassianAPI):
     def decline_pull_request(
         self, project_key: str, repo_slug: str, pr_id: int, pr_version: int
     ) -> dict | None:
-        """
-        Decline a pull request.
+        """Decline a pull request.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -1219,9 +1203,10 @@ class Bitbucket(AtlassianAPI):
         :type repo_slug: str
         :param pr_id: The ID of the pull request.
         :type pr_id: int
-        :param pr_version: The current version of the pull request (required for optimistic locking).
+        :param pr_version: Current pull request version required by Bitbucket
+            optimistic locking.
         :type pr_version: int
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Bitbucket returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/pull-requests/{pr_id}/decline"
@@ -1235,8 +1220,7 @@ class Bitbucket(AtlassianAPI):
         start: int = 0,
         limit: int | None = None,
     ) -> list:
-        """
-        Retrieve all tags for a repository.
+        """Return tags for a repository.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -1246,7 +1230,7 @@ class Bitbucket(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (optional).
         :type limit: int, optional
-        :return: A list of tags in the repository.
+        :return: Tag objects from the paginated ``values`` response.
         :rtype: list
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/tags"
@@ -1265,8 +1249,7 @@ class Bitbucket(AtlassianAPI):
         start_point: str,
         message: str | None = None,
     ) -> dict | None:
-        """
-        Create a new tag in a repository.
+        """Create a lightweight or annotated tag in a repository.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -1276,9 +1259,9 @@ class Bitbucket(AtlassianAPI):
         :type tag_name: str
         :param start_point: The commit SHA or branch name to tag.
         :type start_point: str
-        :param message: An optional message for an annotated tag.
+        :param message: Optional message for an annotated tag.
         :type message: str, optional
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Bitbucket returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/latest/projects/{project_key}/repos/{repo_slug}/tags"

--- a/atlassian/client.py
+++ b/atlassian/client.py
@@ -11,11 +11,14 @@ logger.disabled = True
 
 
 class AtlassianAPI:
-    """
-    Base class for interacting with Atlassian APIs.
+    """Base HTTP client shared by Jira, Bitbucket, and Confluence clients.
 
-    This class provides methods for making HTTP requests (GET, POST, PUT, DELETE)
-    and managing authentication sessions.
+    The client stores a ``requests.Session``, applies either basic auth or a
+    bearer token, appends endpoint paths to the configured base URL, and raises
+    :class:`atlassian.error.APIError` for HTTP ``4xx`` and ``5xx`` responses.
+
+    ``get()`` parses JSON into nested ``SimpleNamespace`` objects. Mutating
+    helpers return decoded JSON dictionaries when available.
     """
 
     default_headers = {"Content-Type": "application/json", "Accept": "application/json"}
@@ -29,20 +32,23 @@ class AtlassianAPI:
         session: requests.Session | None = None,
         token: str | None = None,
     ) -> None:
-        """
-        Initialize the AtlassianAPI instance.
+        """Create a client session for an Atlassian REST API.
 
-        :param url: The base URL of the Atlassian API.
+        :param url: Base URL of the Atlassian product, for example
+            ``https://jira.company.com``. Trailing slashes are removed.
         :type url: str
-        :param username: The username for basic authentication (optional).
+        :param username: Username for basic authentication. Use together with
+            ``password``.
         :type username: str, optional
-        :param password: The password for basic authentication (optional).
+        :param password: Password for basic authentication. Use together with
+            ``username``.
         :type password: str, optional
-        :param timeout: The timeout for HTTP requests in seconds (default is 60).
+        :param timeout: Request timeout in seconds.
         :type timeout: int, optional
-        :param session: A custom requests session (optional).
+        :param session: Existing ``requests.Session`` to reuse. When omitted, a
+            new session is created.
         :type session: requests.Session, optional
-        :param token: The token for bearer authentication (optional).
+        :param token: Bearer token used to set the ``Authorization`` header.
         :type token: str, optional
         """
         self.url = url.strip("/")
@@ -62,8 +68,7 @@ class AtlassianAPI:
             self._create_token_session(token)
 
     def __enter__(self) -> AtlassianAPI:
-        """
-        Enter the runtime context for the API instance.
+        """Return the client for ``with`` statement usage.
 
         :return: The API instance.
         :rtype: AtlassianAPI
@@ -76,8 +81,7 @@ class AtlassianAPI:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        """
-        Exit the runtime context and close the session.
+        """Close the session when leaving a ``with`` block.
 
         :param exc_type: The exception type (if any).
         :type exc_type: type
@@ -89,8 +93,7 @@ class AtlassianAPI:
         self.close()
 
     def _create_basic_session(self, username: str, password: str) -> None:
-        """
-        Create a session with basic authentication.
+        """Apply username/password authentication to the current session.
 
         :param username: The username for authentication.
         :type username: str
@@ -100,8 +103,7 @@ class AtlassianAPI:
         self._session.auth = (username, password)
 
     def _create_token_session(self, token: str) -> None:
-        """
-        Create a session with bearer token authentication.
+        """Apply bearer token authentication to the current session.
 
         :param token: The bearer token for authentication.
         :type token: str
@@ -109,8 +111,7 @@ class AtlassianAPI:
         self._update_header("Authorization", f"Bearer {token}")
 
     def _update_header(self, key: str, value: str) -> None:
-        """
-        Update the headers for the current session.
+        """Set or replace a header on the current session.
 
         :param key: The header key to update.
         :type key: str
@@ -121,12 +122,12 @@ class AtlassianAPI:
 
     @staticmethod
     def _response_handler(response: requests.Response) -> dict | None:
-        """
-        Handle the HTTP response and parse JSON content.
+        """Decode a response body as JSON.
 
         :param response: The HTTP response object.
         :type response: requests.Response
-        :return: The parsed JSON content or None if parsing fails.
+        :return: The parsed JSON content, or ``None`` when the response is
+            empty or cannot be parsed as JSON.
         :rtype: dict or None
         """
         try:
@@ -139,11 +140,7 @@ class AtlassianAPI:
             return None
 
     def close(self) -> None:
-        """
-        Close the current session.
-
-        :return: None
-        """
+        """Close the underlying ``requests.Session``."""
         self._session.close()
 
     def request(
@@ -154,18 +151,18 @@ class AtlassianAPI:
         json: object | None = None,
         params: dict | None = None,
     ) -> requests.Response:
-        """
-        Make an HTTP request.
+        """Send an HTTP request through the configured session.
 
         :param method: The HTTP method (e.g., "GET", "POST", "PUT", "DELETE").
         :type method: str
-        :param path: The API endpoint path.
+        :param path: Endpoint path appended to ``self.url``. Include the leading
+            slash, for example ``/rest/api/2/project``.
         :type path: str
-        :param data: The data to send in the request body (optional).
+        :param data: Form data or bytes to send in the request body.
         :type data: dict or None
-        :param json: The JSON payload to send in the request body (optional).
+        :param json: JSON payload to send in the request body.
         :type json: object or None
-        :param params: The query parameters for the request (optional).
+        :param params: Query string parameters.
         :type params: dict or None
         :return: The HTTP response object.
         :rtype: requests.Response
@@ -195,16 +192,16 @@ class AtlassianAPI:
         data: dict | None = None,
         params: dict | None = None,
     ) -> SimpleNamespace | str | None:
-        """
-        Make a GET request.
+        """Send a ``GET`` request and parse the response for script-friendly use.
 
-        :param path: The API endpoint path.
+        :param path: Endpoint path appended to the base URL.
         :type path: str
-        :param data: The data to send in the request body (optional).
+        :param data: Optional request body data.
         :type data: dict or None
-        :param params: The query parameters for the request (optional).
+        :param params: Query string parameters.
         :type params: dict or None
-        :return: The parsed JSON response or raw text if parsing fails.
+        :return: A nested ``SimpleNamespace`` for JSON responses, raw text when
+            JSON parsing fails, or ``None`` for empty responses.
         :rtype: SimpleNamespace or str or None
         :raises APIError: If the response status code is 4xx or 5xx.
         """
@@ -226,18 +223,17 @@ class AtlassianAPI:
         json: object | None = None,
         params: dict | None = None,
     ) -> dict | None:
-        """
-        Make a POST request.
+        """Send a ``POST`` request.
 
-        :param path: The API endpoint path.
+        :param path: Endpoint path appended to the base URL.
         :type path: str
-        :param data: The data to send in the request body (optional).
+        :param data: Optional request body data.
         :type data: dict or None
-        :param json: The JSON payload to send in the request body (optional).
+        :param json: JSON payload to send in the request body.
         :type json: object or None
-        :param params: The query parameters for the request (optional).
+        :param params: Query string parameters.
         :type params: dict or None
-        :return: The parsed JSON response or None if parsing fails.
+        :return: Decoded JSON response, or ``None`` for empty/non-JSON responses.
         :rtype: dict or None
         :raises APIError: If the response status code is 4xx or 5xx.
         """
@@ -251,18 +247,17 @@ class AtlassianAPI:
         json: object | None = None,
         params: dict | None = None,
     ) -> dict | None:
-        """
-        Make a PUT request.
+        """Send a ``PUT`` request.
 
-        :param path: The API endpoint path.
+        :param path: Endpoint path appended to the base URL.
         :type path: str
-        :param data: The data to send in the request body (optional).
+        :param data: Optional request body data.
         :type data: dict or None
-        :param json: The JSON payload to send in the request body (optional).
+        :param json: JSON payload to send in the request body.
         :type json: object or None
-        :param params: The query parameters for the request (optional).
+        :param params: Query string parameters.
         :type params: dict or None
-        :return: The parsed JSON response or None if parsing fails.
+        :return: Decoded JSON response, or ``None`` for empty/non-JSON responses.
         :rtype: dict or None
         :raises APIError: If the response status code is 4xx or 5xx.
         """
@@ -276,18 +271,17 @@ class AtlassianAPI:
         json: object | None = None,
         params: dict | None = None,
     ) -> dict | None:
-        """
-        Make a DELETE request.
+        """Send a ``DELETE`` request.
 
-        :param path: The API endpoint path.
+        :param path: Endpoint path appended to the base URL.
         :type path: str
-        :param data: The data to send in the request body (optional).
+        :param data: Optional request body data.
         :type data: dict or None
-        :param json: The JSON payload to send in the request body (optional).
+        :param json: JSON payload to send in the request body.
         :type json: object or None
-        :param params: The query parameters for the request (optional).
+        :param params: Query string parameters.
         :type params: dict or None
-        :return: The parsed JSON response or None if parsing fails.
+        :return: Decoded JSON response, or ``None`` for empty/non-JSON responses.
         :rtype: dict or None
         :raises APIError: If the response status code is 4xx or 5xx.
         """

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -10,18 +10,22 @@ logger = get_logger(__name__)
 
 
 class Confluence(AtlassianAPI):
-    """
-    Confluence API Reference
+    """Client for Confluence REST API operations.
+
+    Use this class for pages, spaces, content search, child pages, attachments,
+    and labels. Read methods return nested ``SimpleNamespace`` objects when the
+    API returns JSON, raw text for non-JSON responses, or ``None`` for empty
+    responses.
 
     .. seealso::
         `Confluence REST API Documentation <https://docs.atlassian.com/ConfluenceServer/rest/7.17.2/>`_
     """
 
     def get_content(self) -> SimpleNamespace | str | None:
-        """
-        Retrieve all content from Confluence.
+        """Return content visible to the current user.
 
-        :return: A SimpleNamespace containing all content, the raw text response, or None.
+        :return: Content data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = "/rest/api/content"
@@ -35,20 +39,20 @@ class Confluence(AtlassianAPI):
         ancestors_id: int | None = None,
         type: str = "page",
     ) -> dict | None:
-        """
-        Create new content in Confluence.
+        """Create a Confluence page or another content type.
 
         :param title: The title of the content.
         :type title: str
         :param space_key: The key of the space where the content will be created.
         :type space_key: str
-        :param body_value: The body of the content in storage format.
+        :param body_value: Body content in Confluence storage format.
         :type body_value: str
-        :param ancestors_id: The ID of the parent content (optional).
+        :param ancestors_id: Parent content ID. When provided, the new page is
+            created as a child of that content.
         :type ancestors_id: int, optional
-        :param type: The type of the content (e.g., "page").
+        :param type: Content type, for example ``page``.
         :type type: str
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Confluence returns no body.
         :rtype: dict or None
         """
         url = "/rest/api/content"
@@ -71,18 +75,17 @@ class Confluence(AtlassianAPI):
         body_value: str,
         type: str = "page",
     ) -> dict | None:
-        """
-        Update existing content in Confluence.
+        """Update an existing Confluence content item.
 
         :param page_id: The ID of the content to update.
         :type page_id: int
         :param title: The new title of the content.
         :type title: str
-        :param body_value: The new body of the content in storage format.
+        :param body_value: New body content in Confluence storage format.
         :type body_value: str
-        :param type: The type of the content (e.g., "page").
+        :param type: Content type, for example ``page``.
         :type type: str
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Confluence returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/content/{page_id}"
@@ -97,37 +100,36 @@ class Confluence(AtlassianAPI):
         return self.put(url, json=json)
 
     def delete_content(self, page_id: int) -> dict | None:
-        """
-        Delete content from Confluence.
+        """Delete content from Confluence by content ID.
 
         :param page_id: The ID of the content to delete.
         :type page_id: int
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Confluence returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/content/{page_id}"
         return self.delete(url)
 
     def get_content_by_id(self, page_id: int) -> SimpleNamespace | str | None:
-        """
-        Retrieve content by its ID.
+        """Return content by content ID.
 
         :param page_id: The ID of the content to retrieve.
         :type page_id: int
-        :return: A SimpleNamespace containing the content details, the raw text response, or None.
+        :return: Content data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/content/{page_id}"
         return self.get(url)
 
     def get_content_history(self, page_id: int) -> SimpleNamespace | str | None:
-        """
-        Retrieve the history of a specific content.
+        """Return version history for a content item.
 
         :param page_id: The ID of the content to retrieve the history for.
         :type page_id: int
-        :return: A SimpleNamespace containing the content history.
-        :rtype: SimpleNamespace or None
+        :return: History data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
+        :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/content/{page_id}/history"
         return self.get(url)
@@ -135,14 +137,14 @@ class Confluence(AtlassianAPI):
     def get_spaces(
         self, start: int = 0, limit: int = 25
     ) -> SimpleNamespace | str | None:
-        """
-        Retrieve all spaces.
+        """Return Confluence spaces visible to the current user.
 
         :param start: The starting index for pagination (default 0).
         :type start: int, optional
         :param limit: The maximum number of spaces to return (default 25).
         :type limit: int, optional
-        :return: A SimpleNamespace containing spaces, the raw text response, or None.
+        :return: Space data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = "/rest/api/space"
@@ -150,12 +152,12 @@ class Confluence(AtlassianAPI):
         return self.get(url, params=params)
 
     def get_space(self, space_key: str) -> SimpleNamespace | str | None:
-        """
-        Retrieve a specific space by its key.
+        """Return a Confluence space by space key.
 
         :param space_key: The key of the space to retrieve.
         :type space_key: str
-        :return: A SimpleNamespace containing the space details, the raw text response, or None.
+        :return: Space data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/space/{space_key}"
@@ -168,8 +170,7 @@ class Confluence(AtlassianAPI):
         start: int = 0,
         limit: int = 25,
     ) -> SimpleNamespace | str | None:
-        """
-        Retrieve content (pages or blog posts) within a specific space.
+        """Return pages or blog posts in a Confluence space.
 
         :param space_key: The key of the space.
         :type space_key: str
@@ -179,7 +180,8 @@ class Confluence(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (default 25).
         :type limit: int, optional
-        :return: A SimpleNamespace containing the content list, the raw text response, or None.
+        :return: Content list data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = "/rest/api/content"
@@ -194,8 +196,7 @@ class Confluence(AtlassianAPI):
     def search_content(
         self, cql: str, start: int = 0, limit: int = 25
     ) -> SimpleNamespace | str | None:
-        """
-        Search for content using Confluence Query Language (CQL).
+        """Search content with Confluence Query Language (CQL).
 
         :param cql: The CQL query string.
         :type cql: str
@@ -203,7 +204,8 @@ class Confluence(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (default 25).
         :type limit: int, optional
-        :return: A SimpleNamespace containing the search results, the raw text response, or None.
+        :return: Search result data, raw response text for non-JSON responses,
+            or ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = "/rest/api/content/search"
@@ -213,8 +215,7 @@ class Confluence(AtlassianAPI):
     def get_child_pages(
         self, page_id: int, start: int = 0, limit: int = 25
     ) -> SimpleNamespace | str | None:
-        """
-        Retrieve the child pages of a specific page.
+        """Return child pages for a parent page.
 
         :param page_id: The ID of the parent page.
         :type page_id: int
@@ -222,7 +223,8 @@ class Confluence(AtlassianAPI):
         :type start: int, optional
         :param limit: The maximum number of results to return (default 25).
         :type limit: int, optional
-        :return: A SimpleNamespace containing the child pages, the raw text response, or None.
+        :return: Child page data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/content/{page_id}/child/page"
@@ -230,38 +232,37 @@ class Confluence(AtlassianAPI):
         return self.get(url, params=params)
 
     def get_attachments(self, page_id: int) -> SimpleNamespace | str | None:
-        """
-        Retrieve all attachments for a specific page.
+        """Return attachments for a page.
 
         :param page_id: The ID of the page.
         :type page_id: int
-        :return: A SimpleNamespace containing the attachments, the raw text response, or None.
+        :return: Attachment data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/content/{page_id}/child/attachment"
         return self.get(url)
 
     def get_labels(self, page_id: int) -> SimpleNamespace | str | None:
-        """
-        Retrieve all labels for a specific piece of content.
+        """Return labels for a content item.
 
         :param page_id: The ID of the content.
         :type page_id: int
-        :return: A SimpleNamespace containing the labels, the raw text response, or None.
+        :return: Label data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/content/{page_id}/label"
         return self.get(url)
 
     def add_label(self, page_id: int, label: str) -> dict | None:
-        """
-        Add a label to a specific piece of content.
+        """Add a global label to a content item.
 
         :param page_id: The ID of the content.
         :type page_id: int
         :param label: The label name to add.
         :type label: str
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Confluence returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/content/{page_id}/label"
@@ -269,14 +270,13 @@ class Confluence(AtlassianAPI):
         return self.post(url, json=payload)
 
     def remove_label(self, page_id: int, label: str) -> dict | None:
-        """
-        Remove a label from a specific piece of content.
+        """Remove a label from a content item.
 
         :param page_id: The ID of the content.
         :type page_id: int
         :param label: The label name to remove.
         :type label: str
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Confluence returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/content/{page_id}/label"

--- a/atlassian/error.py
+++ b/atlassian/error.py
@@ -1,8 +1,11 @@
-"""
-HTTP Response Codes:
-https://developer.atlassian.com/server/confluence/http-response-code-definitions/
+"""HTTP error helpers used by the Atlassian clients.
 
-This module defines HTTP response codes and provides an `APIError` class for handling API errors.
+``AtlassianAPI.request()`` raises ``APIError`` for HTTP ``4xx`` and ``5xx``
+responses. The exception keeps the status code and the response text so callers
+can log or branch on the failure.
+
+HTTP response code reference:
+https://developer.atlassian.com/server/confluence/http-response-code-definitions/
 """
 
 from __future__ import annotations
@@ -53,25 +56,21 @@ _ERROR_CODE_MESSAGE = {
 
 
 class APIError(Exception):
-    """
-    Exception class for handling API errors.
-
-    This class represents an error response from an API, including the HTTP status code
-    and a corresponding error message.
+    """Exception raised when an Atlassian REST API request fails.
 
     :param code: The HTTP status code of the error.
     :type code: int, optional
-    :param message: A custom error message. If not provided, a default message based on the code will be used.
+    :param message: Response body or custom error message. If omitted, a
+        default message is selected from the status code.
     :type message: str, optional
     """
 
     def __init__(self, code: int | None = None, message: str | None = None) -> None:
-        """
-        Initialize the APIError instance.
+        """Create an API error with a status code and message.
 
         :param code: The HTTP status code of the error.
         :type code: int, optional
-        :param message: A custom error message. If not provided, a default message based on the code will be used.
+        :param message: Response body or custom error message.
         :type message: str, optional
         """
         self.code = code
@@ -85,8 +84,7 @@ class APIError(Exception):
             )
 
     def __str__(self) -> str:
-        """
-        Return a string representation of the error.
+        """Return a readable ``Error [code] : message`` string.
 
         :return: A formatted string containing the error code and message.
         :rtype: str

--- a/atlassian/jira.py
+++ b/atlassian/jira.py
@@ -9,32 +9,36 @@ logger = get_logger(__name__)
 
 
 class Jira(AtlassianAPI):
-    """
-    JIRA API Reference
+    """Client for Jira REST API operations.
+
+    Use this class for issue lookup, issue updates, JQL searches, comments,
+    watchers, transitions, projects, and versions. Responses from read methods
+    are usually nested ``SimpleNamespace`` objects; methods that mutate Jira
+    return decoded JSON dictionaries or ``None`` for empty responses.
 
     .. seealso::
-        `JIRA REST API Documentation <https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/>`_
+        `Jira REST API Documentation <https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/>`_
     """
 
     def issue(self, issue_key: str) -> SimpleNamespace | str | None:
-        """
-        Get issue fields.
+        """Return a Jira issue by key.
 
         :param issue_key: The key of the issue to retrieve.
         :type issue_key: str
-        :return: A SimpleNamespace containing issue fields, a raw text response string, or None.
+        :return: Issue data with fields accessible through dot notation, raw
+            response text for non-JSON responses, or ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/2/issue/{issue_key}"
         return self.get(url)
 
     def issue_changelog(self, issue_key: str) -> SimpleNamespace | str | None:
-        """
-        Get issue changelog.
+        """Return an issue with changelog data expanded.
 
         :param issue_key: The key of the issue to retrieve the changelog for.
         :type issue_key: str
-        :return: A SimpleNamespace containing the issue changelog, a raw text response string, or None.
+        :return: Issue data including ``changelog`` and ``summary`` fields, raw
+            response text for non-JSON responses, or ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/2/issue/{issue_key}?expand=changelog&fields=summary"
@@ -46,16 +50,15 @@ class Jira(AtlassianAPI):
         add_labels: list[str] | None = None,
         remove_labels: list[str] | None = None,
     ) -> dict | None:
-        """
-        Update issue labels.
+        """Add and/or remove labels on an issue.
 
         :param issue_key: The key of the issue to update.
         :type issue_key: str
-        :param add_labels: A list of labels to add.
+        :param add_labels: Labels to add to the issue.
         :type add_labels: list[str], optional
-        :param remove_labels: A list of labels to remove.
+        :param remove_labels: Labels to remove from the issue.
         :type remove_labels: list[str], optional
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/2/issue/{issue_key}"
@@ -85,16 +88,15 @@ class Jira(AtlassianAPI):
         add_components: list[str] | None = None,
         remove_components: list[str] | None = None,
     ) -> dict | None:
-        """
-        Update issue components.
+        """Add and/or remove components on an issue by component name.
 
         :param issue_key: The key of the issue to update.
         :type issue_key: str
-        :param add_components: A list of components to add.
+        :param add_components: Component names to add.
         :type add_components: list[str], optional
-        :param remove_components: A list of components to remove.
+        :param remove_components: Component names to remove.
         :type remove_components: list[str], optional
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/2/issue/{issue_key}"
@@ -122,14 +124,13 @@ class Jira(AtlassianAPI):
     def update_issue_description(
         self, issue_key: str, new_description: str
     ) -> dict | None:
-        """
-        Update issue description.
+        """Replace an issue description.
 
         :param issue_key: The key of the issue to update.
         :type issue_key: str
         :param new_description: The new description for the issue.
         :type new_description: str
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/2/issue/{issue_key}"
@@ -143,18 +144,17 @@ class Jira(AtlassianAPI):
         add: str | None = None,
         remove: str | None = None,
     ) -> dict | None:
-        """
-        Update a specific field of an issue.
+        """Add and/or remove named values from an issue field.
 
         :param issue_key: The key of the issue to update.
         :type issue_key: str
-        :param field_name: The name of the field to update.
+        :param field_name: Jira field name or custom field ID to update.
         :type field_name: str
-        :param add: The value to add to the field.
+        :param add: Value name to add to the field.
         :type add: str, optional
-        :param remove: The value to remove from the field.
+        :param remove: Value name to remove from the field.
         :type remove: str, optional
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/2/issue/{issue_key}"
@@ -169,15 +169,14 @@ class Jira(AtlassianAPI):
     def add_issue_comment(
         self, issue_key: str, content: str | None = None
     ) -> dict | None:
-        """
-        Add a comment to an issue.
+        """Add a plain text comment to an issue.
 
         :param issue_key: The key of the issue to add a comment to.
         :type issue_key: str
         :param content: The content of the comment.
         :type content: str, optional
 
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/2/issue/{issue_key}/comment"
@@ -185,14 +184,13 @@ class Jira(AtlassianAPI):
         return self.post(url, json=json)
 
     def delete_issue_comment(self, issue_key: str, comment_id: str) -> dict | None:
-        """
-        Delete a comment from an issue.
+        """Delete a comment from an issue by comment ID.
 
         :param issue_key: The key of the issue.
         :type issue_key: str
         :param comment_id: The ID of the comment to delete.
         :type comment_id: str
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/2/issue/{issue_key}/comment/{comment_id}"
@@ -204,8 +202,7 @@ class Jira(AtlassianAPI):
         inward_issue: str | None = None,
         outward_issue: str | None = None,
     ) -> dict | None:
-        """
-        Link two issues with a specific relationship.
+        """Link two issues with a Jira issue-link relationship.
 
         :param type_name: The type of the link (e.g., "Dependence", "Blocking").
         :type type_name: str, optional
@@ -213,7 +210,7 @@ class Jira(AtlassianAPI):
         :type inward_issue: str, optional
         :param outward_issue: The key of the outward issue.
         :type outward_issue: str, optional
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
 
         .. code-block:: python
@@ -229,18 +226,21 @@ class Jira(AtlassianAPI):
         return self.post(url, json=json)
 
     def delete_issue_link(self, link_id: str) -> dict | None:
-        """Delete link from issue"""
+        """Delete an issue link by link ID."""
         url = f"/rest/api/2/issueLink/{link_id}"
         return self.delete(url)
 
     def create_issue(self, fields: dict, update: dict | None = None) -> dict | None:
-        """
-        Creates an issue or a sub-task from a JSON representation.
+        """Create an issue or sub-task from a Jira ``fields`` payload.
 
-        :param fields: JSON data. mandatory keys are issuetype, summary and project update: Use it to link issues or update worklog
+        :param fields: Jira fields payload. Common required keys are
+            ``project``, ``summary``, and ``issuetype``.
         :type fields: dict
+        :param update: Optional Jira update payload, for example to add
+            worklog data while creating the issue.
+        :type update: dict, optional
 
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = "/rest/api/2/issue"
@@ -260,8 +260,10 @@ class Jira(AtlassianAPI):
         components: list[str] | None = None,
         issue_type: int = 10,
     ) -> dict | None:
-        """
-        Create task issue.
+        """Create a task with the legacy project-specific payload.
+
+        Prefer :meth:`create_issue` for new code because custom fields and issue
+        type IDs vary between Jira projects.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -277,7 +279,7 @@ class Jira(AtlassianAPI):
         :type components: list[str], optional
         :param issue_type: The issue type ID (default is 10).
         :type issue_type: int, optional
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = "/rest/api/2/issue"
@@ -309,8 +311,10 @@ class Jira(AtlassianAPI):
         team: str | None = None,
         issue_type: int = 20,
     ) -> dict | None:
-        """
-        Create sub task issue.
+        """Create a sub-task with the legacy project-specific payload.
+
+        Prefer :meth:`create_issue` for new code because custom fields and issue
+        type IDs vary between Jira projects.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -330,7 +334,7 @@ class Jira(AtlassianAPI):
         :type team: str, optional
         :param issue_type: The issue type ID (default is 20).
         :type issue_type: int, optional
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = "/rest/api/2/issue"
@@ -357,15 +361,18 @@ class Jira(AtlassianAPI):
     def update_custom_field(
         self, issue_key: str, field_id: str, *field_args: object
     ) -> dict | None:
-        """
-        Update custom field. in my Jira project.
+        """Update a Jira custom field.
 
         :param issue_key: The key of the issue to update.
         :type issue_key: str
         :param field_id: The ID of the custom field to update.
         :type field_id: str
-        :param field_args: The new values for the custom field.
+        :param field_args: One value to set directly, or two values to set a
+            nested object such as ``{"name": "value"}``.
         :type field_args: tuple
+        :return: Decoded API response, or ``None`` when Jira returns no body.
+        :rtype: dict or None
+        :raises AttributeError: If more than two ``field_args`` are provided.
         """
         url = f"/rest/api/2/issue/{issue_key}"
         if len(field_args) == 1:
@@ -378,14 +385,14 @@ class Jira(AtlassianAPI):
         return self.put(url, json=json)
 
     def assign_issue(self, issue_key: str, assignee: str | None = None) -> dict | None:
-        """
-        Assign issue to someone.
+        """Assign an issue to a user or unassign it.
 
         :param issue_key: The key of the issue to assign.
         :type issue_key: str
-        :param assignee: The assignee of the issue.
+        :param assignee: Username to assign. When omitted, ``-1`` is sent to
+            unassign the issue.
         :type assignee: str, optional
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/2/issue/{issue_key}/assignee"
@@ -395,14 +402,13 @@ class Jira(AtlassianAPI):
         return self.put(url, json=json)
 
     def add_issue_watcher(self, issue_key: str, watcher: str) -> dict | None:
-        """
-        Add someone as watcher.
+        """Add a user as an issue watcher.
 
         :param issue_key: The key of the issue to add a watcher to.
         :type issue_key: str
         :param watcher: The username of the watcher.
         :type watcher: str
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/2/issue/{issue_key}/watchers"
@@ -412,16 +418,17 @@ class Jira(AtlassianAPI):
     def issue_transition(
         self, issue_key: str, transition_id: str | None = None
     ) -> dict | None:
-        """Each Jira project may have different transition_id. You can find your transition_id like below:
-        Chose transition Button then right click on the view elements. for example:
-        I find Close button's elements is id="action_id_51", so the close transition_id = 51.
-        I find Open button's elements is id="action_id_61", so the open transition_id = 61.
+        """Move an issue through a Jira workflow transition.
+
+        Transition IDs vary by project and workflow. Call
+        :meth:`get_transitions` first to list the transitions available to the
+        current user, then pass the selected transition ID here.
 
         :param issue_key: The key of the issue to transition.
         :type issue_key: str
         :param transition_id: The ID of the transition to perform.
         :type transition_id: str, optional
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = "/rest/api/2/issue/{key}/transitions".format(key=issue_key)
@@ -429,26 +436,26 @@ class Jira(AtlassianAPI):
         return self.post(url, json=json)
 
     def get_transitions(self, issue_id: str) -> SimpleNamespace | str | None:
-        """
-        Get a list of the transitions possible for this issue by the current user.
+        """Return transitions available for an issue to the current user.
 
         :param issue_id: The ID of the issue to get transitions for.
         :type issue_id: str
-        :return: A SimpleNamespace containing the transitions.
-        :rtype: SimpleNamespace or None
+        :return: Transition data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
+        :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/2/issue/{issue_id}/transitions"
         return self.get(url)
 
     def search_issue_with_jql(self, jql: str, max_result: int = 1000) -> list:
-        """
-        Search issues using JQL (JIRA Query Language).
+        """Search issues using JQL.
 
         :param jql: The JQL query string.
         :type jql: str
-        :param max_result: The maximum number of results to return (default is 1000).
+        :param max_result: Page size requested from Jira for each API call.
         :type max_result: int, optional
-        :return: A list of issues matching the JQL query.
+        :return: Issues matching the query. The current implementation requests
+            ``summary``, ``status``, ``issuetype``, and ``fixVersions`` fields.
         :rtype: list
         """
         url = "/rest/api/2/search"
@@ -484,25 +491,25 @@ class Jira(AtlassianAPI):
         return issues
 
     def get_project_components(self, project_id: str) -> SimpleNamespace | str | None:
-        """
-        Get project components.
+        """Return components configured for a Jira project.
 
         :param project_id: The ID of the project to get components for.
         :type project_id: str
-        :return: A SimpleNamespace containing the project components.
-        :rtype: SimpleNamespace or None
+        :return: Project components, raw response text for non-JSON responses,
+            or ``None`` for an empty body.
+        :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/2/project/{project_id}/components"
         return self.get(url)
 
     def user(self, username: str) -> SimpleNamespace | str | None:
-        """
-        Get user information by username.
+        """Return Jira user information by username.
 
         :param username: The username of the user to retrieve.
         :type username: str
-        :return: A SimpleNamespace containing user information.
-        :rtype: SimpleNamespace or None
+        :return: User data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
+        :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/2/user?username={username}"
         return self.get(url)
@@ -513,8 +520,7 @@ class Jira(AtlassianAPI):
         app_type: str = "stash",
         data_type: str = "repository",
     ) -> SimpleNamespace | str | None:
-        """
-        Get development status for an issue.
+        """Return linked development status for an issue.
 
         :param issue_id: The ID of the issue to get development status for.
         :type issue_id: str
@@ -522,53 +528,53 @@ class Jira(AtlassianAPI):
         :type app_type: str, optional
         :param data_type: The type of data (default is "repository").
         :type data_type: str, optional
-        :return: A SimpleNamespace containing the development status.
-        :rtype: SimpleNamespace or None
+        :return: Development status data, raw response text for non-JSON
+            responses, or ``None`` for an empty body.
+        :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/dev-status/1.0/issue/detail?issueId={issue_id}&applicationType={app_type}&dataType={data_type}"
         return self.get(url)
 
     def delete_issue(self, issue_key: str) -> dict | None:
-        """
-        Delete an issue.
+        """Delete an issue by key.
 
         :param issue_key: The key of the issue to delete.
         :type issue_key: str
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/2/issue/{issue_key}"
         return self.delete(url)
 
     def get_project(self, project_key: str) -> SimpleNamespace | str | None:
-        """
-        Get project information.
+        """Return a Jira project by project key.
 
         :param project_key: The key of the project to retrieve.
         :type project_key: str
-        :return: A SimpleNamespace containing project information.
+        :return: Project data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/2/project/{project_key}"
         return self.get(url)
 
     def get_projects(self) -> SimpleNamespace | str | None:
-        """
-        Get all projects visible to the current user.
+        """Return projects visible to the current user.
 
-        :return: A SimpleNamespace containing all projects.
+        :return: Project list, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = "/rest/api/2/project"
         return self.get(url)
 
     def get_issue_comments(self, issue_key: str) -> SimpleNamespace | str | None:
-        """
-        Get all comments for an issue.
+        """Return comments for an issue.
 
         :param issue_key: The key of the issue.
         :type issue_key: str
-        :return: A SimpleNamespace containing the comments.
+        :return: Comment data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/2/issue/{issue_key}/comment"
@@ -577,8 +583,7 @@ class Jira(AtlassianAPI):
     def update_issue_comment(
         self, issue_key: str, comment_id: str, content: str
     ) -> dict | None:
-        """
-        Update an existing comment on an issue.
+        """Replace the body of an existing issue comment.
 
         :param issue_key: The key of the issue.
         :type issue_key: str
@@ -586,7 +591,7 @@ class Jira(AtlassianAPI):
         :type comment_id: str
         :param content: The new content of the comment.
         :type content: str
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = f"/rest/api/2/issue/{issue_key}/comment/{comment_id}"
@@ -594,24 +599,24 @@ class Jira(AtlassianAPI):
         return self.put(url, json=json)
 
     def get_issue_watchers(self, issue_key: str) -> SimpleNamespace | str | None:
-        """
-        Get all watchers for an issue.
+        """Return watchers for an issue.
 
         :param issue_key: The key of the issue.
         :type issue_key: str
-        :return: A SimpleNamespace containing the watchers.
+        :return: Watcher data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/2/issue/{issue_key}/watchers"
         return self.get(url)
 
     def get_versions(self, project_key: str) -> SimpleNamespace | str | None:
-        """
-        Get all versions for a project.
+        """Return versions configured for a Jira project.
 
         :param project_key: The key of the project.
         :type project_key: str
-        :return: A SimpleNamespace containing the project versions.
+        :return: Version data, raw response text for non-JSON responses, or
+            ``None`` for an empty body.
         :rtype: SimpleNamespace or str or None
         """
         url = f"/rest/api/2/project/{project_key}/versions"
@@ -626,8 +631,7 @@ class Jira(AtlassianAPI):
         start_date: str | None = None,
         release_date: str | None = None,
     ) -> dict | None:
-        """
-        Create a new version for a project.
+        """Create a version in a Jira project.
 
         :param project_key: The key of the project.
         :type project_key: str
@@ -641,7 +645,7 @@ class Jira(AtlassianAPI):
         :type start_date: str, optional
         :param release_date: The release date in YYYY-MM-DD format (optional).
         :type release_date: str, optional
-        :return: The response from the API.
+        :return: Decoded API response, or ``None`` when Jira returns no body.
         :rtype: dict or None
         """
         url = "/rest/api/2/version"

--- a/atlassian/logger.py
+++ b/atlassian/logger.py
@@ -1,4 +1,4 @@
-"""Logger"""
+"""Logging helpers for the Atlassian clients."""
 
 import logging
 import sys
@@ -9,10 +9,9 @@ LOG_FILE = "logs/atlassian-api-py.log"
 
 
 def get_console_handler():
-    """
-    Output log to console
+    """Create a console log handler that writes to stdout.
 
-    :return: StreamHandler
+    :return: Configured stream handler.
     :rtype: StreamHandler
     """
     console_handler = logging.StreamHandler(sys.stdout)
@@ -21,9 +20,12 @@ def get_console_handler():
 
 
 def get_file_handler():
-    """Output log to file
+    """Create a rotating file log handler.
 
-    :return: RotatingFileHandler
+    The caller is responsible for ensuring that the ``logs`` directory exists
+    before attaching this handler.
+
+    :return: Configured rotating file handler.
     :rtype: RotatingFileHandler
     """
     file_handler = RotatingFileHandler(
@@ -34,19 +36,11 @@ def get_file_handler():
 
 
 def get_logger(name):
-    """
-    Get a logger instance
+    """Return a package logger with the project formatter attached.
 
-       Example 'application' code
-       logger.debug('debug message')
-       logger.info('info message')
-       logger.warning('warn message')
-       logger.error('error message')
-       logger.critical('critical message')
-
-    :param name: The name of the logger
+    :param name: Logger name, usually ``__name__``.
     :type name: str
-    :return: A logger instance
+    :return: Configured logger instance.
     :rtype: Logger
     """
     logger = logging.getLogger(name)

--- a/docs/atlassian.rst
+++ b/docs/atlassian.rst
@@ -1,7 +1,17 @@
 API documentation
 =================
 
-Please refer to the ``atlassian`` specific module documentation for detailed information.
+This page lists the public clients and lower-level helpers exposed by the
+``atlassian`` package.
+
+Most scripts should import one of the product clients from ``atlassian``:
+
+.. code-block:: python
+
+   from atlassian import Jira, Bitbucket, Confluence
+
+Use ``atlassian.client.AtlassianAPI`` directly only when you need to call an
+endpoint that does not yet have a convenience method.
 
 atlassian.jira module
 ---------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,5 @@
-.. Atlassian REST API documentation master file, created by
-   sphinx-quickstart on Thu Apr 17 13:21:10 2025.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Welcome to Atlassian REST API's documentation!
-==============================================
+Atlassian API for Python
+========================
 
 .. include:: ../README.rst
    :start-after: start-overview

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,29 +1,49 @@
-
 Usage Guide
 ===========
 
-This guide demonstrates how to connect to Atlassian Jira, Bitbucket, and Confluence using the `atlassian-api-py` library, and how to perform common operations.
+This guide shows the usual path from a new script to common Jira, Bitbucket,
+and Confluence operations.
+
+Before You Start
+----------------
+
+You need three pieces of information:
+
+* The base URL for your Atlassian product, for example
+  ``https://jira.company.com``.
+* Credentials supported by that product: username/password or a bearer token.
+* Product-specific identifiers such as Jira issue keys, Bitbucket project keys,
+  repository slugs, Confluence space keys, or Confluence page IDs.
+
+The library trims trailing slashes from the base URL. Pass paths and IDs exactly
+as they appear in your Atlassian instance.
 
 Authentication
 --------------
 
-You can authenticate using either username/password or a personal access token. Credentials can be provided directly or loaded from a configuration file.
+Create a client for the product you want to call.
 
-Example: Connect to Jira with username and password
-
-.. code-block:: python
-
-   from atlassian import Jira
-   jira = Jira(url="https://jira.company.com", username="your_username", password="your_password")
-
-Example: Connect to Jira with a token
+Username and password:
 
 .. code-block:: python
 
    from atlassian import Jira
+
+   jira = Jira(
+       url="https://jira.company.com",
+       username="your_username",
+       password="your_password",
+   )
+
+Bearer token:
+
+.. code-block:: python
+
+   from atlassian import Jira
+
    jira = Jira(url="https://jira.company.com", token="your_token")
 
-Example: Load credentials from ``config.ini``
+Configuration file:
 
 .. code-block:: ini
 
@@ -31,55 +51,144 @@ Example: Load credentials from ``config.ini``
    url = https://jira.company.com
    username = your_username
    password = your_password
+   # Or use token instead of username/password:
    token = your_token
 
 .. code-block:: python
 
    import configparser
+
+   from atlassian import Jira
+
    config = configparser.ConfigParser()
    config.read("config.ini")
+   section = config["jira"]
+
    jira = Jira(
-       url=config["jira"]["url"],
-       username=config["jira"].get("username"),
-       password=config["jira"].get("password"),
-       token=config["jira"].get("token"),
+       url=section["url"],
+       username=section.get("username"),
+       password=section.get("password"),
+       token=section.get("token"),
    )
 
-Jira Usage
-----------
+Keep local configuration files out of version control when they contain
+credentials.
 
-Get issue fields
+Working With Responses
+----------------------
+
+``GET`` calls parse JSON into nested ``SimpleNamespace`` objects:
 
 .. code-block:: python
 
    issue = jira.issue("TEST-1")
-   print(issue.fields.status.name)      # e.g. "Triage"
-   print(issue.fields.description)      # e.g. "This is a demo Jira ticket"
-   print(issue.fields.issuetype.name)   # e.g. "Bug"
+   print(issue.key)
+   print(issue.fields.summary)
+   print(issue.fields.status.name)
 
-Get additional issue details
+When a ``GET`` response body is not JSON, the raw response text is returned.
+When the response body is empty, ``None`` is returned.
+
+``POST``, ``PUT``, and ``DELETE`` calls return decoded JSON dictionaries when
+the response contains JSON. Empty responses return ``None``.
+
+HTTP ``4xx`` and ``5xx`` responses raise ``APIError``:
 
 .. code-block:: python
 
+   from atlassian.error import APIError
+
+   try:
+       issue = jira.issue("MISSING-1")
+   except APIError as exc:
+       print(f"{exc.code}: {exc.message}")
+
+Clients also work as context managers when you want the underlying
+``requests.Session`` to close automatically:
+
+.. code-block:: python
+
+   from atlassian import Jira
+
+   with Jira(url="https://jira.company.com", token="your_token") as jira:
+       issue = jira.issue("TEST-1")
+       print(issue.fields.summary)
+
+Jira
+----
+
+Read an issue:
+
+.. code-block:: python
+
+   from atlassian import Jira
+
+   jira = Jira(url="https://jira.company.com", token="your_token")
+   issue = jira.issue("TEST-1")
+
    print(issue.id)                     # e.g. 1684517
    print(issue.key)                    # e.g. "TEST-1"
-   print(issue.fields.assignee.key)    # e.g. "xpshen"
-   print(issue.fields.summary)         # e.g. "Jira REST API Unit Test Example"
+   print(issue.fields.summary)         # e.g. "Jira REST API example"
+   print(issue.fields.issuetype.name)  # e.g. "Bug"
 
-Bitbucket Usage
----------------
+Search with JQL:
 
-Get repository information
+.. code-block:: python
+
+   issues = jira.search_issue_with_jql(
+       'project = "TEST" AND status != Done ORDER BY updated DESC',
+       max_result=100,
+   )
+   for issue in issues:
+       print(issue["key"])
+
+Update fields and comments:
+
+.. code-block:: python
+
+   jira.update_issue_label("TEST-1", add_labels=["automation"])
+   jira.update_issue_description("TEST-1", "Updated by automation.")
+   jira.add_issue_comment("TEST-1", "Checked by atlassian-api-py.")
+
+Create an issue with a Jira fields payload:
+
+.. code-block:: python
+
+   jira.create_issue(
+       fields={
+           "project": {"key": "TEST"},
+           "summary": "Created from atlassian-api-py",
+           "issuetype": {"name": "Task"},
+           "description": "This issue was created through the Jira REST API.",
+       }
+   )
+
+Transition an issue:
+
+.. code-block:: python
+
+   transitions = jira.get_transitions("TEST-1")
+   for transition in transitions.transitions:
+       print(transition.id, transition.name)
+
+   jira.issue_transition("TEST-1", transition_id="31")
+
+Bitbucket
+---------
+
+Create a Bitbucket client:
 
 .. code-block:: python
 
    from atlassian import Bitbucket
-   bitbucket = Bitbucket(url="https://bitbucket.company.com", username="your_username", password="your_password")
-   repo_info = bitbucket.get_repo_info("PROJECT_KEY", "repo_slug")
-   print(repo_info.name)               # e.g. "My Repository"
-   print(repo_info.project.key)        # e.g. "PROJECT_KEY"
 
-List repositories in a project
+   bitbucket = Bitbucket(
+       url="https://bitbucket.company.com",
+       username="your_username",
+       password="your_password",
+   )
+
+List repositories in a project:
 
 .. code-block:: python
 
@@ -87,17 +196,117 @@ List repositories in a project
    for repo in repos:
        print(repo.name)
 
-Confluence Usage
-----------------
+Read branches and commits:
 
-Get page information
+.. code-block:: python
+
+   branches = bitbucket.get_repo_branch("PROJECT_KEY", "repo_slug")
+   commits = bitbucket.get_branch_commits("PROJECT_KEY", "repo_slug", "main")
+
+   print(branches[0].displayId)
+   print(commits[0].displayId)
+
+Create and review pull requests:
+
+.. code-block:: python
+
+   bitbucket.create_pull_request(
+       project_key="PROJECT_KEY",
+       repo_slug="repo_slug",
+       title="Add automation update",
+       from_branch="feature/automation",
+       to_branch="main",
+       description="Created from atlassian-api-py.",
+       reviewers=["reviewer_slug"],
+   )
+
+   overview = bitbucket.get_pull_request_overview("PROJECT_KEY", "repo_slug", 123)
+   bitbucket.review_pull_request(
+       "PROJECT_KEY",
+       "repo_slug",
+       pr_id=123,
+       user_slug="your_user_slug",
+       status="APPROVED",
+   )
+
+   # Merge and decline operations require the current pull request version.
+   bitbucket.merge_pull_request("PROJECT_KEY", "repo_slug", 123, overview.version)
+
+Confluence
+----------
+
+Create a Confluence client:
 
 .. code-block:: python
 
    from atlassian import Confluence
-   confluence = Confluence(url="https://confluence.company.com", username="your_username", password="your_password")
-   page = confluence.get_page_by_title("SPACE_KEY", "Page Title")
-   print(page.title)                   # e.g. "My Page"
-   print(page.body)                    # Page content
 
-For more advanced usage and API details, refer to the class references :doc:`atlassian`.
+   confluence = Confluence(
+       url="https://confluence.company.com",
+       username="your_username",
+       password="your_password",
+   )
+
+Read pages and spaces:
+
+.. code-block:: python
+
+   page = confluence.get_content_by_id(123456)
+   print(page.title)
+
+   spaces = confluence.get_spaces(limit=10)
+   for space in spaces.results:
+       print(space.key, space.name)
+
+Search with Confluence Query Language:
+
+.. code-block:: python
+
+   results = confluence.search_content('space = "SPACE" AND type = page')
+   for result in results.results:
+       print(result.title)
+
+Create a page:
+
+.. code-block:: python
+
+   confluence.create_content(
+       title="Automation Notes",
+       space_key="SPACE",
+       body_value="<p>Created from atlassian-api-py.</p>",
+   )
+
+Add and remove labels:
+
+.. code-block:: python
+
+   confluence.add_label(123456, "automation")
+   confluence.remove_label(123456, "automation")
+
+Low-Level Requests
+------------------
+
+Each product client inherits from ``AtlassianAPI``. Use the low-level helpers
+when the project does not yet include a convenience method for an endpoint:
+
+.. code-block:: python
+
+   result = jira.get("/rest/api/2/project/TEST")
+   jira.post("/rest/api/2/issue/TEST-1/comment", json={"body": "Hello"})
+
+Paths are appended to the base URL exactly as provided.
+
+Troubleshooting
+---------------
+
+``401`` or ``403`` errors usually mean the credentials are invalid or the
+authenticated user does not have permission for that resource.
+
+``404`` errors usually mean the base URL, project key, repository slug, issue
+key, or page ID does not match the target Atlassian instance.
+
+If a value is missing from a response object, inspect the raw Atlassian REST API
+response for that endpoint and confirm that the field is included for your
+product version and permissions.
+
+For the complete method list, see the class references in :doc:`atlassian`.


### PR DESCRIPTION
## Summary

Improve the user-facing onboarding path for `atlassian-api-py` by expanding the README, Sphinx usage guide, and generated API documentation text.

## What Changed

- Reworked the README with a clearer overview, install commands, quick start, authentication examples, common Jira/Bitbucket/Confluence tasks, response handling, and API error handling.
- Expanded `docs/usage.rst` into a fuller getting-started guide with setup prerequisites, response model notes, context-manager usage, product-specific examples, low-level request usage, and troubleshooting.
- Cleaned up Sphinx index/API reference copy.
- Improved docstrings across the public clients and helper modules so generated API docs describe authentication, pagination, response types, mutation return values, and common parameter expectations more clearly.

## Why

The previous docs showed a few basic examples but did not explain the quickest path from installation to a working script, how responses are shaped, or how users should handle API failures. These updates make the package easier to evaluate and use without reading the source first.

## Validation

- `python3 -m pytest` passed: 198 tests.
- `uv run --extra docs sphinx-build -b html docs docs/build/html` succeeded.
- `git diff --check` passed.

<!-- readthedocs-preview atlassian-api-py start -->
----
📚 Documentation preview 📚: https://atlassian-api-py--82.org.readthedocs.build/

<!-- readthedocs-preview atlassian-api-py end -->